### PR TITLE
Fix(core): Use outline always style in Input and TextArea

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@moai/core",
-	"version": "0.225.0",
+	"version": "0.226.0",
 	"description": "A React UI toolkit for the web 🗿",
 	"main": "dist/cjs.js",
 	"module": "dist/esm.js",

--- a/core/src/input/flat.module.css
+++ b/core/src/input/flat.module.css
@@ -1,4 +1,6 @@
 .main {
+	transition: background-color 0.1s, outline 0.2s ease-out;
+
 	/* Pretty much nothing in normal state */
 	text-align: inherit;
     text-decoration: inherit;

--- a/core/src/input/input.module.css
+++ b/core/src/input/input.module.css
@@ -5,7 +5,6 @@
 
 .input {
 	width: 100%;
-	transition: background-color 0.1s, outline 0.2s ease-out;
 }
 
 .icon {

--- a/core/src/input/outset.module.css
+++ b/core/src/input/outset.module.css
@@ -1,4 +1,6 @@
 .main {
+	transition: background-color 0.1s, outline 0.2s ease-out;
+
 	border-width: 1px;
 	border-style: solid;
 	--shadow-size: 0px 0.5px 1.5px inset;

--- a/core/src/text-area/text-area.tsx
+++ b/core/src/text-area/text-area.tsx
@@ -10,13 +10,7 @@ export interface TextAreaSize {
 const getClass = (props: TextAreaProps) => {
 	const style = props.style ?? TextArea.styles.outset;
 	const size = props.size ?? TextArea.sizes.medium;
-	return [
-		s.container,
-		outline.normal,
-		style.main,
-		size.main,
-		props.disabled ? style.disabled : "",
-	].join(" ");
+	return [s.container, outline.always, style.main, size.main].join(" ");
 };
 
 type ChangeEvent = React.ChangeEvent<HTMLTextAreaElement>;


### PR DESCRIPTION
It was wrong to use outline.normal in Input and TextArea, as outline.normal is only applied via focus-visible. The correct usage is to use outline.always, which is focus only