### PR TITLE
Docs(core): Bring back gallery

### DIFF
--- a/core/.storybook/preview.js
+++ b/core/.storybook/preview.js
@@ -25,7 +25,7 @@ export const parameters = {
 	options: {
 		storySort: {
 			method: "alphabetical",
-			order: ["Quick Start", "Proper Start", "Gallery"],
+			order: ["Quick Start", "Proper Start", "Widget Gallery"],
 		},
 	},
 };

--- a/core/docs/proper-start.stories.mdx
+++ b/core/docs/proper-start.stories.mdx
@@ -4,6 +4,11 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 # Proper Start
 
+If you are in a hurry, see the [Quick Start] instead. This page covers the same
+steps but with more explanation and tips.
+
+[Quick Start]: /?path=/docs/quick-start--page.
+
 ## 1. Install
 
 The [@moai/core] package is the basis of the Moai kit. It provides all basic

--- a/core/src/_gallery/gallery.stories.mdx
+++ b/core/src/_gallery/gallery.stories.mdx
@@ -1,0 +1,10 @@
+import { Gallery } from "./gallery";
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Widget Gallery" />
+
+# Widget Gallery
+
+<div style={{ fontSize: 14 }}>
+	<Gallery toolbarVisible={false} />
+</div>

--- a/core/src/_gallery/gallery.stories.mdx.backup
+++ b/core/src/_gallery/gallery.stories.mdx.backup
@@ -1,8 +1,0 @@
-import { Gallery } from "./gallery";
-import { Meta } from "@storybook/addon-docs/blocks";
-
-<Meta title="Gallery" />
-
-<div style={{ marginTop: -24, fontSize: 14 }}>
-	<Gallery />
-</div>

--- a/core/src/_gallery/gallery.tsx
+++ b/core/src/_gallery/gallery.tsx
@@ -23,10 +23,18 @@ import { GalleryToolbar } from "./toolbar/toolbar";
 
 export { GallerySection };
 
-export const Gallery = () => (
+interface Props {
+	toolbarVisible: boolean;
+}
+
+export const Gallery = (props: Props): JSX.Element => (
 	<div className={scrollbar.custom}>
-		<GalleryToolbar />
-		<DivPx size={32} />
+		{props.toolbarVisible && (
+			<>
+				<GalleryToolbar />
+				<DivPx size={32} />
+			</>
+		)}
 		<GallerySection title="Buttons">
 			<GalleryButtonStyle />
 			<GalleryButtonFunction />


### PR DESCRIPTION
This add an option for Gallery to hide its Toolbar (and thus, does not have Theme controlled). This allows us to bring back the gallery into the doc.