### PR TITLE
Build(core): Enforce latest installs before starting local development

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -9,8 +9,8 @@
 		"dist"
 	],
 	"scripts": {
-		"rollup": "rollup --config",
-		"storybook": "start-storybook --no-manager-cache -p 6006",
+		"rollup": "yarn && rollup --config",
+		"storybook": "yarn && start-storybook --no-manager-cache -p 6006",
 		"build": "build-storybook -c .storybook -o public",
 		"prepublishOnly": "yarn rollup",
 		"postpublish": "yarn report",


### PR DESCRIPTION
This does not need for website build scripts since they should be run on CI which already includes the installation.