### PR TITLE
Fix(core): Make Table behaves more like native

### DIFF
--- a/core/src/_gallery/table/table.module.css
+++ b/core/src/_gallery/table/table.module.css
@@ -4,68 +4,27 @@
 	overflow: auto;
 }
 
-.container th input {
-	font-weight: 400;
+/* Quick fix to un-bold the inputs in header */
+.container th input,
+.container th select {
+	font-weight: 425;
 }
 
-.container th {
-	vertical-align: top;
-}
-
-.overview {
-	width: 240px;
-	text-align: left;
-}
-
-/* First column of expandable table */
-.overviewCell {
+.actions {
 	display: flex;
-	align-items: center;
-}
-
-.email {
-	width: 200px;
-	text-align: left;
-}
-
-.mac {
-	width: 200px;
-	text-align: left;
-	font-feature-settings: "tnum";
-}
-
-td.mac > div {
-	display: flex;
-	align-items: center;
-}
-
-.lastSeen {
-	width: 200px;
-	text-align: left;
-	font-feature-settings: "tnum";
 }
 
 .materials {
-	width: 320px;
-	text-align: left;
-}
-
-td.materials > div {
 	display: flex;
-	flex-wrap: wrap;
-	margin: -4px 0;
 }
 
-td.materials > div > div {
-	padding: 4px;
-}
-
-.action {
-	width: 240px;
-	text-align: right;
-}
-
-td.action > div {
+.overview {
 	display: flex;
-	justify-content: flex-end;
+	align-items: center;
+	white-space: nowrap;
+}
+
+.mac {
+	display: flex;
+	align-items: center;
 }

--- a/core/src/_gallery/table/table.tsx
+++ b/core/src/_gallery/table/table.tsx
@@ -1,4 +1,6 @@
+import { Fragment } from "react";
 import * as M from "..";
+import { DivPx } from "../../div/div";
 import { Robot, ROBOTS } from "./robots";
 import s from "./table.module.css";
 
@@ -17,7 +19,7 @@ const SearchHeader = ({ children }: { children: string }): JSX.Element => (
 );
 
 const Overview: Column = ({ robot }) => (
-	<div className={s.overviewCell}>
+	<div className={s.overview}>
 		<img
 			width="32"
 			height="32"
@@ -42,7 +44,7 @@ const LastSeenHeader = (): JSX.Element => (
 );
 
 const Action: Column = ({ robot }) => (
-	<div>
+	<div className={s.actions}>
 		{robot.deployed ? (
 			<M.Button highlight children="Deploy" />
 		) : (
@@ -84,14 +86,15 @@ const MaterialsHeader = (): JSX.Element => (
 );
 
 const Materials: Column = ({ robot }) => (
-	<div>
-		{robot.materials.map((material) => (
-			<div key={material}>
+	<div className={s.materials}>
+		{robot.materials.map((material, index) => (
+			<Fragment key={material}>
+				{index > 0 && <DivPx size={4} />}
 				<M.Tag
 					color={(MATERIAL_TAGS as any)[material]}
 					children={material}
 				/>
-			</div>
+			</Fragment>
 		))}
 	</div>
 );
@@ -108,7 +111,7 @@ const Note: Column = ({ robot }) => (
 );
 
 const Mac: Column = ({ robot }) => (
-	<div>
+	<div className={s.mac}>
 		<M.Button
 			size={M.Button.sizes.small}
 			icon={M.coreIcons.duplicate}
@@ -123,32 +126,26 @@ const getColumns = (): M.TableColumn<Robot>[] => [
 	{
 		title: <SearchHeader children="Bot" />,
 		render: (robot) => <Overview robot={robot} />,
-		className: s.overview,
 	},
 	{
 		title: <LastSeenHeader />,
 		render: (robot) => <LastSeen robot={robot} />,
-		className: s.lastSeen,
 	},
 	{
 		title: <SearchHeader children="MAC" />,
 		render: (robot) => <Mac robot={robot} />,
-		className: s.mac,
 	},
 	{
 		title: <MaterialsHeader />,
 		render: (robot) => <Materials robot={robot} />,
-		className: s.materials,
 	},
 	{
 		title: <SearchHeader children="Email" />,
 		render: "email",
-		className: s.email,
 	},
 	{
 		title: "Action",
 		render: (robot) => <Action robot={robot} />,
-		className: s.action,
 	},
 ];
 
@@ -160,6 +157,7 @@ export const GalleryTable = (): JSX.Element => (
 				columns={getColumns()}
 				rowKey={(robot) => robot.id}
 				expandRowRender={(robot) => <Note robot={robot} />}
+				fixed
 			/>
 		</div>
 	</M.Pane>

--- a/core/src/table/fixed.module.css
+++ b/core/src/table/fixed.module.css
@@ -1,0 +1,40 @@
+/* First column */
+.container th:first-child,
+.container td:first-child {
+	position: sticky;
+	left: 0;
+	z-index: var(--z-sticky-1);
+}
+
+@media (max-width: 640px) {
+	.container td:first-child,
+	.container th:first-child {
+		/* Leave enough space for the rest of columns to be scrolled.
+		"max-width: 50%" is better but it does not apply for td and th */
+		width: 160px;
+	}
+}
+
+/* Heading */
+.container th {
+	position: sticky;
+	top: 0;
+	z-index: var(--z-sticky-1);
+}
+
+/* Fix z-index of the special top-left cell */
+.container th:first-child {
+	z-index: var(--z-sticky-2);
+}
+
+/* Visual touch to make first column stands out more */
+.container td:first-child,
+.container th:first-child {
+	padding-right: 16px;
+	border-right-width: 1px;
+	border-right-style: solid;
+}
+.container td:nth-child(2),
+.container th:nth-child(2) {
+	padding-left: 16px;
+}

--- a/core/src/table/table.module.css
+++ b/core/src/table/table.module.css
@@ -1,22 +1,32 @@
+/* Try to have as little CSS here as possible, so that our tables behave like
+in native HTML */
+
+/* container is the "table" tag */
 .container {
-	position: relative;
 	/* To make heading's bottom border visible while scrolling */
 	border-collapse: separate;
+	/* Avoid actually "separate" the borders */
 	border-spacing: 0;
-	table-layout: fixed;
-	width: 100%;
-	overflow-wrap: normal;
 }
+
+/* Cell spacing */
 
 .container th,
 .container td {
-	overflow: hidden;
 	padding: 12px 8px;
-	text-overflow: ellipsis;
-
-	border-bottom-style: solid;
-	border-bottom-width: 1px;
 }
+
+.container td:first-child,
+.container th:first-child {
+	padding-left: 16px;
+}
+
+.container td:last-child,
+.container th:last-child {
+	padding-right: 16px;
+}
+
+/* Row's background change on hover */
 
 /* Same as background.weak */
 :global(.light) .container tr:hover td {
@@ -26,51 +36,14 @@
 	background-color: var(--gray-8);
 }
 
+/* Bordering */
+
+.container th,
+.container td {
+	border-bottom-style: solid;
+	border-bottom-width: 1px;
+}
+
 .container tr:last-child td {
 	border-bottom-style: none;
-}
-
-.container td:first-child,
-.container th:first-child {
-	position: sticky;
-	left: 0;
-	border-right-style: solid;
-	border-right-width: 1px;
-	padding-left: 16px;
-	padding-right: 16px;
-}
-
-.container td:first-child {
-	z-index: var(--z-sticky-1);
-}
-
-@media (max-width: 640px) {
-	.container td:first-child,
-	.container th:first-child {
-		/* Leave enough space for the rest of columns to be scrolled. It's
-		better to use "max-width: 50%" but it does not apply for td and th */
-		width: 160px;
-	}
-}
-
-.container td:nth-child(2),
-.container th:nth-child(2) {
-	padding-left: 16px;
-}
-
-.container td:last-child,
-.container th:last-child {
-	padding-right: 16px;
-}
-
-.container th {
-	position: sticky;
-	top: 0;
-	z-index: var(--z-sticky-1);
-	border-bottom-width: 1px;
-	border-bottom-style: solid;
-}
-
-.container th:first-child {
-	z-index: var(--z-sticky-2);
 }

--- a/core/src/table/table.stories.tsx
+++ b/core/src/table/table.stories.tsx
@@ -23,36 +23,51 @@ export const Basic = () => {
 	// The definition of interface here is only for explanation purpose. In
 	// practice the interface/type/model should already be defined outside of
 	// your component.
-	interface Person {
-		id: number;
-		name: string;
-		email: string;
+	interface Book {
+		isbn: number;
+		title: string;
+		author: string;
 	}
 
 	return (
-		<Table<Person>
+		<Table<Book>
 			rows={[
-				{ id: 0, name: "Jensen", email: "jensen.romaguera@gmail.com" },
-				{ id: 1, name: "Enos", email: "enos@yahoo.com" },
-				{ id: 2, name: "Kasey", email: "kaseykoelpin@hotmail.com" },
+				{
+					isbn: 9780679783268,
+					title: "Pride and Prejudic",
+					author: "Jane Austen",
+				},
+				{
+					isbn: 9780743273565,
+					title: "The Great Gatsby",
+					author: "Francis Scott Fitzgerald",
+				},
+				{
+					isbn: 9780684830490,
+					title: "The Old Man and the Sea",
+					author: "Ernest Hemingway",
+				},
 			]}
-			rowKey={(person) => person.id.toString()}
+			rowKey={(book) => book.isbn.toString()}
 			columns={[
-				{ title: "Name", render: "name" },
-				{ title: "Email", render: "email" },
+				{ title: "Title", render: "title" },
+				{ title: "Author", render: "author" },
 			]}
 		/>
 	);
 };
 
 _Story.desc(Basic)(`
-To display your data with the Table component, first provide the data via
-the \`rows\` prop, then describe how to render them with the \`columns\`
-prop, and how to get their keys with the \`rowKey\` prop. See the argument
-table above for the details of these props.
+Every table requires 3 props: \`rows\`, \`columns\` and \`rowKey\`. See the
+argument table above for the detail of these props.
 
-Note that Table does not have any border or shadow built-in. For that, you can
-wrap it inside a \`Pane\` component.
+The CSS of Moai's Table is kept [as little as possible][1] to preserve the
+native behaviour of the \`table\` tag. For example, the size of a table depends
+on its content, while text breaks ["normally"][2]. It also doesn't have any
+outer border or shadow. For that, use the \`Pane\` component.
+
+[1]: https://github.com/moaijs/moai/blob/main/core/src/table/table.module.css
+[2]: https://developer.mozilla.org/en-US/docs/Web/CSS/word-break
 `);
 
 export const Fixed = () => (
@@ -65,16 +80,7 @@ export const Fixed = () => (
 .fixed-table {
 	height: 200px; /* limit the height of the table */
 	overflow: auto; /* show scrollbar(s) */
-}
-.fixed-table .name {
-	width: 160px;
-}
-/* For demo purpose, we intentionally define big width for these columns so
-that the table's width exceeds the width of its container (.fixed-table) */
-.fixed-table .id,
-.fixed-table .seen,
-.fixed-table .email {
-	width: 500px;
+	white-space: nowrap;
 }
 				`,
 			}}
@@ -84,29 +90,30 @@ that the table's width exceeds the width of its container (.fixed-table) */
 				rows={ROBOTS}
 				rowKey={(robot) => robot.id.toString()}
 				columns={[
-					{ title: "Bot", className: "name", render: "MAC" },
-					{ title: "Id", className: "id", render: "id" },
-					{ title: "Seen", className: "seen", render: "lastSeen" },
-					{ title: "Email", className: "email", render: "email" },
+					{ title: "Bot", render: "MAC" },
+					{ title: "Id", render: "id" },
+					{ title: "Seen", render: "lastSeen" },
+					{ title: "Email", render: "email" },
+					{ title: "Avatar", render: "avatar" },
 				]}
+				fixed
 			/>
 		</div>
 	</div>
 );
 
 _Story.desc(Fixed)(`
-Out of the box, the Table component takes 100% of the horizontal space (i.e. 
-\`width: 100%\`) and as much vertical space as necessary (i.e.
-\`height: fit-content\`).
+If the \`fixed\` prop is set to \`true\`, the table's header and first column
+would stay fixed while the user scrolls the rest of the table. Note that the
+fixed position here is relative to the table's nearets scrolling ancestor. In
+practice, this means the container of the table should have:
 
-If the table's width is bigger than its container's width (which is usually
-when its columns' \`(min-)width\` are defined), there will be a horizontal
-scrollbar. When the user scrolls, the first column is kept fixed on the left
-sided. Likewise, when the height of the table is limited, there will be a
-vertical scrollbar, with the table's header is kept fixed at top.
+- "auto" or "scroll" overflow, and
+- a defined height, either fixed (e.g. "400px") or relative (e.g. "100%")
 
-Note that technically the table's container (\`.fixed-table\` in this example)
-is the table's "viewport" and it is where scrollbars are defined.
+Since Moai's Table doesn't alter the line breaking CSS, you may also need
+\`white-space: nowrap\` or defining width for your columns to avoid the default
+line break behaviour.
 `);
 
 export const Expandable = () => (
@@ -117,13 +124,13 @@ export const Expandable = () => (
 			{ title: "Bot", className: "name", render: "MAC" },
 			{ title: "Id", render: "id" },
 		]}
-		expandRowRender={(robot) => robot.note}
+		expandRowRender={(robot) => robot.email}
 	/>
 );
 
 _Story.desc(Expandable)(`
 The users can expand a table's rows if the \`expandRowRender\` is prop provided.
 It should be a function that returns what to be rendered when the user expands
-a row. The returned result is rendered below the row, spanning all columns (i.e.
-\`colSpan={columns.length}\`).
+a row. The returned result is rendered below the row, spanning all columns
+(i.e. a \`td\` with \`colSpan={columns.length}\`).
 `);

--- a/core/src/table/table.tsx
+++ b/core/src/table/table.tsx
@@ -2,6 +2,7 @@ import { ReactNode, useState } from "react";
 import { background } from "../background/background";
 import { border } from "../border/border";
 import { text } from "../text/text";
+import fixed from "./fixed.module.css";
 import { getTableRow } from "./row/row";
 import s from "./table.module.css";
 
@@ -30,30 +31,39 @@ export interface TableColumn<R> {
 
 export interface TableProps<R> {
 	/**
-	 * Rows of the Table. The type of Row is [generic][1], which is usually the
-	 * interface of a model.
+	 * An array of [generic][1] items to render as rows of the table (e.g. a
+	 * list of `Book`).
+	 * 
 	 * [1]: https://www.typescriptlang.org/docs/handbook/generics.html
 	 */
 	rows: R[];
 	/**
-	 * A function that returns the [key][1] of a Row.
+	 * A function to return the [React's key][1] of an item (e.g. a book's
+	 * ISBN).
+	 * 
 	 * [1]: https://reactjs.org/docs/lists-and-keys.html#keys
 	 */
 	rowKey: (row: R) => string;
 	/**
-	 * Columns of the Table. See the "TableColumn" tab for detail.
+	 * An array of `TableColumn`s which describe how to render the table's
+	 * `rows` (e.g. a book's title, author). See the "TableColumn" tab for
+	 * detail.
 	 */
 	columns: TableColumn<R>[];
 	/**
-	 * A [render prop][1] that enables row expanding. Setting this prop will
-	 * add a button to each row that allows users to expand or collapse it.
-	 *
-	 * This should return the React element to be rendered when the given row
-	 * is expanded.
+	 * A [render prop][1] that, when set, allows users to expand or collapse
+	 * the table's rows. This should return the React element to be rendered
+	 * when a row is expanded.
 	 *
 	 * [1]: https://reactjs.org/docs/render-props.html
 	 */
 	expandRowRender?: (row: R) => ReactNode;
+	/**
+	 * Whether to fix the table's header and first column position while the
+	 * rest is scrolled. These positions are relative to the table's nearest
+	 * scrolling ancestor (i.e. one with "auto" or "scroll" overflow).
+	 */
+	fixed?: boolean;
 }
 
 const thCls = [border.weak, background.weak, text.strong].join(" ");
@@ -85,8 +95,15 @@ export const Table = <R,>(props: TableProps<R>) => {
 		const elements = getTableRow({ row, state, table: props });
 		body.push(...elements);
 	});
+
 	return (
-		<table className={[s.container, background.strong].join(" ")}>
+		<table
+			className={[
+				s.container,
+				props.fixed ? fixed.container : "",
+				background.strong,
+			].join(" ")}
+		>
 			<thead>
 				<tr>{props.columns.map(renderTh)}</tr>
 			</thead>


### PR DESCRIPTION
There are 2 problems with the current implementation of Table:
- The "fixed" mode is always on, which causes some side-effects even if the consumer doesn't need the "fixed" mode (e.g. the right border of the first column).
- There are unnecessary, too opinionated built-in CSS such as "table-layout: fixed" and "overflow-wrap: normal" and even "width: 100%". This makes the behaviour of Moai's table very far from the native one.

This commit fixes both issues by:
- Extract the "fixed" mode and have a prop for it, and:
- Reduce the built-in CSS to minimum

See the "Table" doc page for demo.