### PR TITLE
Fix(core): Fix TableGallery line break

### DIFF
--- a/core/src/_gallery/table/table.module.css
+++ b/core/src/_gallery/table/table.module.css
@@ -2,6 +2,7 @@
 	height: 400px;
 	width: 100%;
 	overflow: auto;
+	white-space: nowrap;
 }
 
 /* Quick fix to un-bold the inputs in header */
@@ -21,7 +22,6 @@
 .overview {
 	display: flex;
 	align-items: center;
-	white-space: nowrap;
 }
 
 .mac {


### PR DESCRIPTION
Don't know why I missed this

<img width="1278" alt="image" src="https://user-images.githubusercontent.com/5953369/112426500-9e7d6580-8d6a-11eb-8440-e8ddf133d895.png">
