### PR TITLE
Fix: Update link for Quick Start

### DIFF
--- a/core/docs/proper-start.stories.mdx
+++ b/core/docs/proper-start.stories.mdx
@@ -7,7 +7,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 If you are in a hurry, see the [Quick Start] instead. This page covers the same
 steps but with more explanation and tips.
 
-[Quick Start]: /?path=/docs/quick-start--page.
+[Quick Start]: /?path=/docs/quick-start--page
 
 ## 1. Install
 


### PR DESCRIPTION
The bug causes we're unable to navigate to Quick Start from Proper Start