### PR TITLE
Refactor(core): Improve Table sizing

### DIFF
--- a/core/src/table/sizes.module.css
+++ b/core/src/table/sizes.module.css
@@ -1,0 +1,44 @@
+.small th,
+.small td {
+	padding: 8px 8px;
+}
+
+.small td:first-child,
+.small th:first-child {
+	padding-left: 16px;
+}
+
+.small td:last-child,
+.small th:last-child {
+	padding-right: 16px;
+}
+
+.medium th,
+.medium td {
+	padding: 12px 8px;
+}
+
+.medium td:first-child,
+.medium th:first-child {
+	padding-left: 16px;
+}
+
+.medium td:last-child,
+.medium th:last-child {
+	padding-right: 16px;
+}
+
+.large th,
+.large td {
+	padding: 16px 8px;
+}
+
+.large td:first-child,
+.large th:first-child {
+	padding-left: 16px;
+}
+
+.large td:last-child,
+.large th:last-child {
+	padding-right: 16px;
+}

--- a/core/src/table/table.module.css
+++ b/core/src/table/table.module.css
@@ -11,23 +11,6 @@ in native HTML */
 .containerFill {
 	/* To make the table takes 100% of its container width */
 	min-width: 100%;
-
-}
-/* Cell spacing */
-
-.container th,
-.container td {
-	padding: 12px 8px;
-}
-
-.container td:first-child,
-.container th:first-child {
-	padding-left: 16px;
-}
-
-.container td:last-child,
-.container th:last-child {
-	padding-right: 16px;
 }
 
 /* Row's background change on hover */
@@ -50,54 +33,4 @@ in native HTML */
 
 .container tr:last-child td {
 	border-bottom-style: none;
-}
-
-/* Cell spacing */
-
-/* Medium */
-.medium th,
-.medium td {
-	padding: 12px 8px;
-}
-
-.medium td:first-child,
-.medium th:first-child {
-	padding-left: 16px;
-}
-
-.medium td:last-child,
-.medium th:last-child {
-	padding-right: 16px;
-}
-
-.small th,
-.small td {
-	padding: 8px 6px;
-}
-
-/* Small */
-.small td:first-child,
-.small th:first-child {
-	padding-left: 12px;
-}
-
-.small td:last-child,
-.small th:last-child {
-	padding-right: 12px;
-}
-
-/* Large */
-.large th,
-.large td {
-	padding: 16px 12px;
-}
-
-.large td:first-child,
-.large th:first-child {
-	padding-left: 24px;
-}
-
-.large td:last-child,
-.large th:last-child {
-	padding-right: 24px;
 }

--- a/core/src/table/table.stories.tsx
+++ b/core/src/table/table.stories.tsx
@@ -1,9 +1,11 @@
 import { Meta } from "@storybook/react";
+import { useState } from "react";
+import { DivPx, Select, SelectOption } from "../_gallery";
 import { Robot, ROBOTS } from "../_gallery/table/robots";
 import { GalleryTable } from "../_gallery/table/table";
 import { _Story } from "../_story";
 import { TableColumn } from "./fake-table-column";
-import { Table } from "./table";
+import { Table, TableSize } from "./table";
 
 export default {
 	title: "Components/Table",
@@ -154,18 +156,36 @@ a row. The returned result is rendered below the row, spanning all columns
 (i.e. a \`td\` with \`colSpan={columns.length}\`).
 `);
 
-export const SizedTable = () => (
-	<Table<Robot>
-		rows={ROBOTS.slice(0, 3)}
-		rowKey={(robot) => robot.id.toString()}
-		columns={[
-			{ title: "Bot", className: "name", render: "MAC" },
-			{ title: "Id", render: "id" },
-		]}
-		size={Table.sizes.small}
-	/>
-);
+export const Size = () => {
+	const [size, setSize] = useState<TableSize>(Table.sizes.small);
+	const options: SelectOption<TableSize>[] = [
+		{ id: "small", label: "Small", value: Table.sizes.small },
+		{ id: "medium", label: "Medium", value: Table.sizes.medium },
+		{ id: "large", label: "Large", value: Table.sizes.large },
+	];
+	return (
+		<div>
+			<Select<TableSize>
+				value={size}
+				setValue={setSize}
+				options={options}
+			/>
+			<DivPx size={16} />
+			<Table<Robot>
+				rows={ROBOTS.slice(0, 3)}
+				rowKey={(robot) => robot.id.toString()}
+				columns={[
+					{ title: "Bot", className: "name", render: "MAC" },
+					{ title: "Id", render: "id" },
+				]}
+				size={size}
+			/>
+		</div>
+	);
+};
 
-_Story.desc(SizedTable)(`
-User can also define table cell size with \`size\` prop.
+_Story.desc(Size)(`
+To make a table looks more compact or loose, use the \`size\` prop. It controls
+the vertical padding of a table's cells. Choose a value from the \`Table.sizes\`
+list.
 `);

--- a/core/src/table/table.tsx
+++ b/core/src/table/table.tsx
@@ -2,7 +2,8 @@ import { ReactNode, useState } from "react";
 import { background } from "../background/background";
 import { border } from "../border/border";
 import { text } from "../text/text";
-import fixed from "./fixed.module.css";
+import sFixed from "./fixed.module.css";
+import sSizes from "./sizes.module.css";
 import { getTableRow } from "./row/row";
 import s from "./table.module.css";
 
@@ -75,11 +76,11 @@ export interface TableProps<R> {
 	 */
 	fixed?: TableFixed;
 	/**
-	 *	 when you want to make the table takes 100% of its container width
+	 * To make the table takes 100 of its container's width
 	 */
 	fill?: boolean;
 	/**
-	 * Size of the table. Choose one from Table.sizes.
+	 * Size of the table's cells. Choose one from `Table.sizes`.
 	 */
 	size?: TableSize;
 }
@@ -116,10 +117,10 @@ export const Table = <R,>(props: TableProps<R>) => {
 
 	const fixedTableClass = props.fixed
 		? [
-				fixed.container,
-				props.fixed.header && fixed.header,
-				props.fixed.firstColumn && fixed.firstColumn,
-				props.fixed.lastColumn && fixed.lastColumn,
+				sFixed.container,
+				props.fixed.header && sFixed.header,
+				props.fixed.firstColumn && sFixed.firstColumn,
+				props.fixed.lastColumn && sFixed.lastColumn,
 		  ].filter((e) => typeof e === "string")
 		: [];
 
@@ -142,7 +143,7 @@ export const Table = <R,>(props: TableProps<R>) => {
 };
 
 Table.sizes = {
-	large: { cell: s.large } as TableSize,
-	medium: { cell: s.medium } as TableSize,
-	small: { cell: s.small } as TableSize,
+	large: { cell: sSizes.large } as TableSize,
+	medium: { cell: sSizes.medium } as TableSize,
+	small: { cell: sSizes.small } as TableSize,
 };


### PR DESCRIPTION
A follow up of @tuhuynh27 's #103 

- Extract the sizing CSS into its own file
- Delete duplicated CSS in main table css file
- Docs: Improve the Size section
- Docs: Add Select to switch between Table.sizes
- Fix: Keep the horizontal padding between Table.sizes