### PR TITLE
Chore(root): Treat all eslint warnings as errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "@moai/root",
 	"license": "MIT",
 	"scripts": {
-		"eslint": "eslint .",
+		"eslint": "eslint --max-warnings=0 .",
 		"prettier": "prettier --check .",
 		"test": "yarn eslint && yarn prettier"
 	},


### PR DESCRIPTION
Fix: https://github.com/moaijs/moai/issues/139