### PR TITLE
Types(core): Use Interface for ButtonSize, SelectStyle, TableSize

### DIFF
--- a/core/src/button/button.tsx
+++ b/core/src/button/button.tsx
@@ -15,11 +15,11 @@ export interface ButtonStyle {
 	busy: string;
 }
 
-export type ButtonSize = {
+export interface ButtonSize {
 	main: string;
 	iconSize: IconSize;
 	iconMargin: DivSize;
-};
+}
 
 const getClass = (props: ButtonProps) => {
 	const size = props.size ?? Button.sizes.medium;

--- a/core/src/select/select.tsx
+++ b/core/src/select/select.tsx
@@ -7,9 +7,9 @@ import { coreIcons } from "../icons/icons";
 import { outline } from "../outline/outline";
 import s from "./select.module.css";
 
-export type SelectStyle = {
+export interface SelectStyle {
 	select: string;
-};
+}
 
 export interface SelectSize {
 	select: string;

--- a/core/src/table/table.tsx
+++ b/core/src/table/table.tsx
@@ -30,9 +30,9 @@ export interface TableColumn<R> {
 		| ((row: R, index: number) => ReactNode); // Render function;
 }
 
-export type TableSize = {
+export interface TableSize {
 	cell: string;
-};
+}
 
 export interface TableFixed {
 	firstColumn?: boolean;


### PR DESCRIPTION
Use Interface instead of Type for ButtonSize, SelectStyle and TableSize.