### PR TITLE
Docs(core): Re-order documentation

### DIFF
--- a/core/.storybook/preview.js
+++ b/core/.storybook/preview.js
@@ -25,7 +25,12 @@ export const parameters = {
 	options: {
 		storySort: {
 			method: "alphabetical",
-			order: ["Quick Start", "Proper Start", "Widget Gallery"],
+			order: [
+				"Guides",
+				["Quick Start", "Proper Start"],
+				"Components",
+				["Component Gallery"],
+			],
 		},
 	},
 };

--- a/core/.storybook/preview.js
+++ b/core/.storybook/preview.js
@@ -28,6 +28,7 @@ export const parameters = {
 			order: [
 				"Guides",
 				["Quick Start", "Proper Start"],
+				"Patterns",
 				"Components",
 				["Component Gallery"],
 			],

--- a/core/docs/proper-start.stories.mdx
+++ b/core/docs/proper-start.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/addon-docs/blocks";
 
-<Meta title="Proper Start" />
+<Meta title="Guides/Proper Start" />
 
 # Proper Start
 

--- a/core/docs/quick-start.stories.mdx
+++ b/core/docs/quick-start.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/addon-docs/blocks";
 
-<Meta title="Quick Start" />
+<Meta title="Guides/Quick Start" />
 
 # Quick Start
 

--- a/core/src/_gallery/button/size.tsx
+++ b/core/src/_gallery/button/size.tsx
@@ -40,7 +40,7 @@ export const GalleryButtonSize = (): JSX.Element => (
 			<div className={s.flex}>
 				<Button children="Previous" icon={go.GoChevronLeft} />
 				<DivPx size={8} />
-				<Button children="Next" icon={go.GoChevronRight} reverse />
+				<Button children="Next" icon={go.GoChevronRight} iconRight />
 			</div>
 			<DivPx size={8} />
 			<IconRow disabled={false} />

--- a/core/src/_gallery/gallery.stories.mdx
+++ b/core/src/_gallery/gallery.stories.mdx
@@ -1,7 +1,7 @@
 import { Gallery } from "./gallery";
 import { Meta } from "@storybook/addon-docs/blocks";
 
-<Meta title="Widget Gallery" />
+<Meta title="Components/Component Gallery" />
 
 # Widget Gallery
 

--- a/core/src/_story.tsx
+++ b/core/src/_story.tsx
@@ -54,8 +54,16 @@ const name = (story: any, text: string): void => {
 	story.storyName = text;
 };
 
-const StickyPage = (): JSX.Element => (
-	<div>
+const PageNoPrimary = (): JSX.Element => (
+	<>
+		<D.Title />
+		<D.Description />
+		<D.Stories />
+	</>
+);
+
+const PageStickyPrimary = (): JSX.Element => (
+	<>
 		<D.Title />
 		<D.Subtitle />
 		<D.Description />
@@ -66,7 +74,7 @@ const StickyPage = (): JSX.Element => (
 			<D.ArgsTable story={D.PRIMARY_STORY} />
 		</div>
 		<D.Stories />
-	</div>
+	</>
 );
 
 /**
@@ -102,8 +110,16 @@ export const _Story = {
 	 * Override the story's name
 	 */
 	name,
-	/**
-	 * Make the Primary story sticky for the ArgsTable
-	 */
-	StickyPage,
+	page: {
+		/**
+		 * Make the Primary story sticky so the user can see effects of
+		 * controls in the ArgsTable
+		 */
+		stickyPrimary: PageStickyPrimary,
+		/**
+		 * Skip the rendering of Primary (and its ArgsTable). Useful for
+		 * Pattern pages
+		 */
+		noPrimary: PageNoPrimary,
+	},
 };

--- a/core/src/button/button.stories.tsx
+++ b/core/src/button/button.stories.tsx
@@ -37,7 +37,7 @@ export default {
 		target: _Story.arg(null, "Link"),
 		href: _Story.arg(null, "Link"),
 	},
-	parameters: { docs: { page: _Story.StickyPage } },
+	parameters: { docs: { page: _Story.page.stickyPrimary } },
 } as Meta;
 
 interface Props {

--- a/core/src/checkbox/checkbox.stories.tsx
+++ b/core/src/checkbox/checkbox.stories.tsx
@@ -3,11 +3,11 @@ import { Checkbox } from "./checkbox";
 import { DivPx } from "../div/div";
 
 export default {
-	title: "Checkbox",
+	title: "Draft/Checkbox",
 	component: Checkbox,
 } as Meta;
 
-export const Main = (): JSX.Element => (
+export const Primary = (): JSX.Element => (
 	<div>
 		<Checkbox indeterminate>Checkbox</Checkbox>
 		<DivPx size={8} />

--- a/core/src/empty/empty.stories.tsx
+++ b/core/src/empty/empty.stories.tsx
@@ -1,9 +1,15 @@
-import { storiesOf } from "@storybook/react";
-import { EmptyState } from "../empty/empty";
+import { Meta } from "@storybook/react";
+import React from "react";
 import { Button } from "../button/button";
 import { Dialog } from "../dialog/dialog";
+import { EmptyState } from "../empty/empty";
 
-storiesOf("Empty", module).add("Main", () => (
+export default {
+	title: "Draft/Empty",
+	component: EmptyState,
+} as Meta;
+
+export const Primary = (): JSX.Element => (
 	<div>
 		<EmptyState message="Error connection, please wait." />
 		<br />
@@ -21,4 +27,4 @@ storiesOf("Empty", module).add("Main", () => (
 			}
 		/>
 	</div>
-));
+);

--- a/core/src/form/form.stories.tsx
+++ b/core/src/form/form.stories.tsx
@@ -1,4 +1,3 @@
-import { Description, Stories, Title } from "@storybook/addon-docs/blocks";
 import { Meta } from "@storybook/react/types-6-0";
 import { useForm, Controller } from "react-hook-form";
 import { ErrorMessage, Field, Form, Formik, FormikErrors } from "formik";
@@ -10,16 +9,10 @@ import { _Story } from "../_story";
 import { FormError } from "./form";
 
 export default {
-	title: "Guides/Form",
+	title: "Patterns/Form",
 	parameters: {
 		docs: {
-			page: () => (
-				<>
-					<Title />
-					<Description />
-					<Stories />
-				</>
-			),
+			page: _Story.page.noPrimary,
 			description: {
 				component: `
 Moai doesn't come with a built-in form solution. Instead, our input components

--- a/core/src/pagination/pagination.tsx
+++ b/core/src/pagination/pagination.tsx
@@ -69,7 +69,7 @@ export const Pagination = (props: PaginationProps): JSX.Element => {
 						<Button
 							busy={busy}
 							icon={coreIcons.kebab}
-							reverse
+							iconRight
 							selected={popover.opened}
 							onClick={popover.toggle}
 						>

--- a/core/src/pane/pane.stories.tsx
+++ b/core/src/pane/pane.stories.tsx
@@ -1,9 +1,14 @@
-import { storiesOf } from "@storybook/react"; //eslint-disable-line
+import { Meta } from "@storybook/react";
 import React from "react";
 import { DivPx } from "../div/div";
 import { Pane } from "./pane";
 
-storiesOf("Pane", module).add("Default", () => (
+export default {
+	title: "Draft/Pane",
+	component: Pane,
+} as Meta;
+
+export const Primary = (): JSX.Element => (
 	<div>
 		<Pane>Content</Pane>
 		<DivPx size={16} />
@@ -13,4 +18,4 @@ storiesOf("Pane", module).add("Default", () => (
 			<Pane fullHeight>Content</Pane>
 		</div>
 	</div>
-));
+);

--- a/core/src/progress/circle.stories.tsx
+++ b/core/src/progress/circle.stories.tsx
@@ -1,8 +1,14 @@
-import { storiesOf } from "@storybook/react";
+import { Meta } from "@storybook/react";
+import React from "react";
 import { DivPx } from "../div/div";
 import { ProgressCircle } from "./circle";
 
-storiesOf("Progress", module).add("Circle", () => (
+export default {
+	title: "Draft/Progress Circle",
+	component: ProgressCircle,
+} as Meta;
+
+export const Primary = (): JSX.Element => (
 	<div>
 		<div>
 			<ProgressCircle size={16} value="indeterminate" />
@@ -24,4 +30,4 @@ storiesOf("Progress", module).add("Circle", () => (
 			/>
 		</div>
 	</div>
-));
+);

--- a/core/src/step/step.stories.tsx
+++ b/core/src/step/step.stories.tsx
@@ -1,7 +1,12 @@
-import { storiesOf } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { Steps } from "./step";
 
-storiesOf("Steps", module).add("Main", () => (
+export default {
+	title: "Draft/Steps",
+	component: Steps,
+} as Meta;
+
+export const Primary = (): JSX.Element => (
 	<Steps
 		steps={[
 			{ title: "First" },
@@ -10,4 +15,4 @@ storiesOf("Steps", module).add("Main", () => (
 		]}
 		current={1}
 	/>
-));
+);

--- a/core/src/tab/tab.stories.tsx
+++ b/core/src/tab/tab.stories.tsx
@@ -1,18 +1,23 @@
-import { storiesOf } from "@storybook/react"; //eslint-disable-line
-import React from "react";
+import { Meta } from "@storybook/react";
+import { useEffect, useState } from "react";
 import { DivPx } from "../div/div";
 import { Switcher } from "../switcher/switcher";
 import { Tab, Tabs } from "./tab";
+
+export default {
+	title: "Draft/Tabs",
+	component: Tabs,
+} as Meta;
 
 const tabs: Tab[] = [
 	{ id: "first", title: "First", pane: () => <p>1st</p> },
 	{ id: "second", title: "Second", pane: () => <p>2nd</p> },
 ];
 
-storiesOf("Tab", module).add("Primary", () => {
-	const [tab, setTab] = React.useState("first");
+export const Primary = (): JSX.Element => {
+	const [tab, setTab] = useState("first");
 
-	React.useEffect(() => {
+	useEffect(() => {
 		console.log(`active tab is changed: ${tab}`);
 	}, [tab]);
 
@@ -49,4 +54,4 @@ storiesOf("Tab", module).add("Primary", () => {
 			</div>
 		</div>
 	);
-});
+};

--- a/core/src/tag/tag.stories.tsx
+++ b/core/src/tag/tag.stories.tsx
@@ -1,9 +1,14 @@
-import { storiesOf } from "@storybook/react";
-import React from "react";
+import { Meta } from "@storybook/react";
+import { Fragment } from "react";
 import { DivPx } from "../div/div";
 import { Tag } from "./tag";
 
-storiesOf("Tag", module).add("Main", () => {
+export default {
+	title: "Draft/Tag",
+	component: Tag,
+} as Meta;
+
+export const Primary = (): JSX.Element => {
 	const colors: string[] = [
 		"red",
 		"yellow",
@@ -19,10 +24,10 @@ storiesOf("Tag", module).add("Main", () => {
 		<div>
 			<div style={{ display: "flex" }}>
 				{colors.map((color) => (
-					<React.Fragment key={color}>
+					<Fragment key={color}>
 						<Tag color={Tag.colors[color]}>{color}</Tag>
 						<DivPx size={8} />
-					</React.Fragment>
+					</Fragment>
 				))}
 			</div>
 			<DivPx size={16} />
@@ -33,4 +38,4 @@ storiesOf("Tag", module).add("Main", () => {
 			</div>
 		</div>
 	);
-});
+};


### PR DESCRIPTION
This brings the "Guides" to top, then "Components", then not-ready (actually not-documented) components ("Draft").

Just see the sidebar in the "core" deployment