### PR TITLE
Fix(core): Expose IconComponent type

### DIFF
--- a/core/src/button/button.tsx
+++ b/core/src/button/button.tsx
@@ -1,8 +1,7 @@
 import { forwardRef } from "react";
-import { IconType } from "react-icons";
 import { border } from "../border/border";
 import { DivPx, DivSize } from "../div/div";
-import { Icon, IconSize } from "../icon/icon";
+import { IconComponent, Icon, IconSize } from "../icon/icon";
 import { outline } from "../outline/outline";
 import { ProgressCircle, ProgressCircleColor } from "../progress/circle";
 import s from "./button.module.css";
@@ -120,7 +119,7 @@ export interface ButtonProps {
 	 *
 	 * [1]: /docs/guides-icons--primary
 	 */
-	icon?: IconType;
+	icon?: IconComponent;
 	/**
 	 * Place the icon on the right side of the button
 	 */
@@ -159,7 +158,7 @@ export const ButtonChildren = (props: ButtonProps): JSX.Element => {
 				<span className={s.icon}>
 					<Icon
 						size={size.iconSize}
-						path={props.icon}
+						component={props.icon}
 						display="block"
 					/>
 				</span>

--- a/core/src/checkbox/checkbox.tsx
+++ b/core/src/checkbox/checkbox.tsx
@@ -72,13 +72,13 @@ export const Checkbox = (props: CheckboxProps): JSX.Element => {
 			/>
 			<span
 				className={[shared.icon, style.icon, self.check].join(" ")}
-				children={<Icon display="block" path={coreIcons.check} />}
+				children={<Icon display="block" component={coreIcons.check} />}
 			/>
 			<span
 				className={[shared.icon, style.icon, self.indeterminate].join(
 					" "
 				)}
-				children={<Icon display="block" path={coreIcons.dash} />}
+				children={<Icon display="block" component={coreIcons.dash} />}
 			/>
 			<span
 				className={[shared.label, style.label].join(" ")}

--- a/core/src/icon/icon.tsx
+++ b/core/src/icon/icon.tsx
@@ -3,14 +3,16 @@ import { IconType } from "react-icons";
 
 export type IconSize = 12 | 16 | 20 | 24 | 32 | 36 | 48;
 
+export type IconComponent = IconType;
+
 export interface IconProps {
 	display: "block" | "inline";
-	path: IconType;
+	component: IconComponent;
 	size?: IconSize;
 }
 
 export const Icon = (props: IconProps): JSX.Element =>
-	props.path({
+	props.component({
 		size: props.size ?? 16,
 		className: props.display === "block" ? s.block : s.inline,
 	});

--- a/core/src/input/input.tsx
+++ b/core/src/input/input.tsx
@@ -1,7 +1,6 @@
 import React from "react";
-import { IconType } from "react-icons";
 import { border } from "../border/border";
-import { Icon, IconSize } from "../icon/icon";
+import { IconComponent, Icon, IconSize } from "../icon/icon";
 import { outline } from "../outline/outline";
 import { text } from "../text/text";
 import sFlat from "./flat.module.css";
@@ -73,13 +72,11 @@ export interface InputProps {
 	list?: { id: string; values: string[] } | string;
 
 	// Style
-	icon?: IconType;
-
+	icon?: IconComponent;
 	/**
 	 * Style of the text box. Choose one from `Input.styles`
 	 */
 	style?: InputStyle;
-
 	/**
 	 * Size of the text box. Choose one from `Input.sizes`
 	 */
@@ -180,7 +177,7 @@ export const Input = (props: InputProps): JSX.Element => {
 				<div className={[s.icon, text.muted, size.icon].join(" ")}>
 					<Icon
 						display="block"
-						path={props.icon}
+						component={props.icon}
 						size={size.iconSize}
 					/>
 				</div>

--- a/core/src/radio/radio.tsx
+++ b/core/src/radio/radio.tsx
@@ -70,7 +70,7 @@ export const Radio = (props: RadioProps): JSX.Element => {
 				ref={props.forwardedRef}
 			/>
 			<span className={[shared.icon, style.icon, self.icon].join(" ")}>
-				<Icon display="block" path={coreIcons.dot} />
+				<Icon display="block" component={coreIcons.dot} />
 			</span>
 			<span className={[shared.label, style.label].join(" ")}>
 				{props.children}

--- a/core/src/select/select.tsx
+++ b/core/src/select/select.tsx
@@ -152,7 +152,7 @@ export const Select = <T,>(props: SelectProps<T>): JSX.Element => {
 			/>
 			<span className={cls.icon}>
 				{/* The "size" is also set in CSS */}
-				<Icon size={12} display="block" path={coreIcons.caret} />
+				<Icon size={12} display="block" component={coreIcons.caret} />
 			</span>
 		</div>
 	);

--- a/core/src/step/step.tsx
+++ b/core/src/step/step.tsx
@@ -30,7 +30,7 @@ const Title = (props: StepProps): JSX.Element => (
 			].join(" ")}
 		>
 			{props.index < props.current ? (
-				<Icon path={coreIcons.check} size={16} display="block" />
+				<Icon component={coreIcons.check} size={16} display="block" />
 			) : (
 				<span>{props.index + 1}</span>
 			)}

--- a/core/src/toast/pane/pane.tsx
+++ b/core/src/toast/pane/pane.tsx
@@ -1,16 +1,15 @@
 import { ReactNode } from "react";
-import { IconType } from "react-icons";
 import { border, Border } from "../../border/border";
 import { Button } from "../../button/button";
 import { DivPx } from "../../div/div";
-import { Icon } from "../../icon/icon";
+import { Icon, IconComponent } from "../../icon/icon";
 import { coreIcons } from "../../icons/icons";
 import { shadow } from "../../shadow/shadow";
 import { Paragraph, text } from "../../text/text";
 import s from "./pane.module.css";
 
 export interface ToastPaneType {
-	iconPath: IconType;
+	iconComponent: IconComponent;
 	iconCls: string;
 }
 
@@ -46,7 +45,7 @@ export const ToastPane = (props: Props): JSX.Element => (
 			className={[s.container, shadow.boxStrong, border.radius].join(" ")}
 		>
 			<div className={[s.icon, props.type.iconCls].join(" ")}>
-				<Icon display="block" path={props.type.iconPath} />
+				<Icon display="block" component={props.type.iconComponent} />
 			</div>
 			<DivPx size={12} />
 			<div className={s.children}>
@@ -60,11 +59,11 @@ export const ToastPane = (props: Props): JSX.Element => (
 
 ToastPane.types = {
 	success: {
-		iconPath: coreIcons.success,
+		iconComponent: coreIcons.success,
 		iconCls: text.successStrong,
 	} as ToastPaneType,
 	failure: {
-		iconPath: coreIcons.error,
+		iconComponent: coreIcons.error,
 		iconCls: text.failureStrong,
 	} as ToastPaneType,
 };


### PR DESCRIPTION
Previously the type of Button's "icon" prop come directly from "react-icons", which is bad. Now it is IconComponent of "@moai/core". It's still the same, but we avoid exposing the underlying dependency.

Also, Icon's "path" is now correctly called "component"