### PR TITLE
Fix(Docs): Table not match with sticky Hero

### DIFF
--- a/core/.storybook/preview.css
+++ b/core/.storybook/preview.css
@@ -2,6 +2,10 @@ html {
 	tab-size: 4;
 }
 
+.moai-table {
+	padding: 1px;
+}
+
 .sbdocs-p {
 	max-width: 640px;
 }
@@ -28,6 +32,8 @@ html {
 
 .docblock-argstable:not(#x) {
 	table-layout: fixed;
+	margin-left: 0;
+	margin-right: 0;
 }
 
 .docblock-argstable-body:not(#x) {

--- a/core/src/_story.tsx
+++ b/core/src/_story.tsx
@@ -69,7 +69,9 @@ const PageStickyPrimary = (): JSX.Element => (
 			<div className={["moai-primary", background.strong].join(" ")}>
 				<D.Primary />
 			</div>
-			<D.ArgsTable story={D.PRIMARY_STORY} />
+			<div className="moai-table">
+				<D.ArgsTable story={D.PRIMARY_STORY} />
+			</div>
 		</div>
 		<D.Stories />
 	</>


### PR DESCRIPTION
Previous:

<img width="1149" alt="image" src="https://user-images.githubusercontent.com/30283022/117791394-7becd080-b274-11eb-87cf-c6069ab99977.png">

Fixed:

<img width="1149" alt="image" src="https://user-images.githubusercontent.com/30283022/117791491-958e1800-b274-11eb-814e-1b7368ea4ffa.png">
