### PR TITLE
Fix(core): Fix tree-shaking!

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@moai/core",
-	"version": "1.0.0-rc9",
+	"version": "1.0.0-rc10",
 	"description": "A React UI toolkit for the web 🗿",
 	"main": "dist/cjs.js",
 	"module": "dist/esm.js",

--- a/core/rollup.config.js
+++ b/core/rollup.config.js
@@ -27,8 +27,8 @@ const postcssOptions = {
 const bundleMain = {
 	input: "src/index.ts",
 	output: [
-		{ file: "dist/cjs.js", format: "cjs" },
-		{ file: "dist/esm.js", format: "esm" },
+		{ dir: "dist/cjs", format: "cjs", preserveModules: true },
+		{ dir: "dist/esm", format: "esm", preserveModules: true },
 	],
 	external: [
 		"@tippyjs/react/headless",

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,9 +1,9 @@
 {
 	"name": "@moai/gallery",
-	"version": "1.0.0",
+	"version": "1.0.0-rc11",
 	"description": "Widget Gallery of Moai 🗿",
-	"main": "dist/index.js",
-	"module": "dist/index.js",
+	"main": "dist/cjs.js",
+	"module": "dist/esm.js",
 	"types": "dist/gallery/src/index.d.ts",
 	"sideEffects": false,
 	"files": [

--- a/gallery/rollup.config.js
+++ b/gallery/rollup.config.js
@@ -11,7 +11,10 @@ import typescript2 from "rollup-plugin-typescript2";
  */
 const config = {
 	input: "src/index.tsx",
-	output: { file: "dist/index.js", format: "esm" },
+	output: [
+		{ file: "dist/esm.js", format: "esm" },
+		{ file: "dist/cjs.js", format: "cjs" },
+	],
 	external: ["@moai/core", "react-icons/go", "react", "react/jsx-runtime"],
 	plugins: [
 		del({

--- a/site/next.config.js
+++ b/site/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	future: {
+		webpack5: true,
+	},
+};

--- a/site/package.json
+++ b/site/package.json
@@ -8,8 +8,9 @@
 		"start": "next start"
 	},
 	"dependencies": {
-		"@moai/core": "1.0.0-rc7",
-		"@types/node": "15.0.2",
+		"@moai/core": "1.0.0-rc10",
+		"@moai/gallery": "1.0.0-rc11",
+		"@types/node": "15.3.0",
 		"@types/react": "17.0.5",
 		"next": "10.2.0",
 		"next-themes": "0.0.14",

--- a/site/pages/_app.tsx
+++ b/site/pages/_app.tsx
@@ -2,7 +2,6 @@ import "@moai/core/dist/font/local.css";
 import "@moai/core/dist/bundle.css";
 import { AppProps } from "next/app";
 import Head from "next/head";
-import { scrollbar } from "@moai/core";
 import { ThemeProvider } from "next-themes";
 
 const favIcon: string = [
@@ -22,7 +21,7 @@ const App = ({ Component, pageProps }: AppProps): JSX.Element => (
 			/>
 		</Head>
 		<ThemeProvider enableSystem attribute="class">
-			<div className={scrollbar.custom}>
+			<div>
 				<Component {...pageProps} />
 			</div>
 		</ThemeProvider>

--- a/site/pages/index.tsx
+++ b/site/pages/index.tsx
@@ -1,6 +1,6 @@
 import { background, Border, DivPx, Paragraph } from "@moai/core";
-import { Gallery, GallerySection } from "@moai/core/dist/_gallery";
-import "@moai/core/dist/_gallery/bundle.css";
+import { Gallery, GallerySection } from "@moai/gallery";
+import "@moai/gallery/dist/bundle.css";
 import { Hero } from "../components/hero/hero";
 import { Toolbar } from "../components/toolbar/toolbar";
 import s from "./index.module.css";

--- a/site/pages/tests/button.tsx
+++ b/site/pages/tests/button.tsx
@@ -1,0 +1,14 @@
+import { Button } from "@moai/core";
+
+const ButtonPage = (): JSX.Element => (
+	<div>
+		<p>
+			This page imports only a Button from Moai. It is meant to test
+			Moai&apos;s tree shaking ability. If tree shaked, this page should
+			be no more than 5kb bigger than the &quot;empty&quot; one.
+		</p>
+		<Button children="Button" />
+	</div>
+);
+
+export default ButtonPage;

--- a/site/pages/tests/dynamic.tsx
+++ b/site/pages/tests/dynamic.tsx
@@ -1,0 +1,27 @@
+import "@moai/gallery/dist/bundle.css";
+import dynamic from "next/dynamic";
+
+const DynamicGallery = dynamic<Record<string, never>>(() =>
+	import("@moai/gallery").then((mod) => mod.Gallery)
+);
+
+const GalleryPage = (): JSX.Element => (
+	<div>
+		<p>
+			This page
+			<span> </span>
+			<a
+				href="https://nextjs.org/docs/advanced-features/dynamic-import"
+				target="_blank"
+				rel="noreferrer"
+				children="DYNAMICALLY"
+			/>
+			<span> </span>
+			imports the whole Component Gallery of Moai. It should be the same
+			size as the &quot;empty&quot; page due to dynamic imports.
+		</p>
+		<DynamicGallery />
+	</div>
+);
+
+export default GalleryPage;

--- a/site/pages/tests/empty.tsx
+++ b/site/pages/tests/empty.tsx
@@ -1,0 +1,8 @@
+const Empty = (): JSX.Element => (
+	<div>
+		This is an empty page. It does not import anything. It is meant to be a
+		based to measure sizes of other pages.
+	</div>
+);
+
+export default Empty;

--- a/site/pages/tests/gallery.tsx
+++ b/site/pages/tests/gallery.tsx
@@ -1,0 +1,14 @@
+import { Gallery } from "@moai/gallery";
+import "@moai/gallery/dist/bundle.css";
+
+const GalleryPage = (): JSX.Element => (
+	<div>
+		<p>
+			This page imports the whole Component Gallery of Moai. It should be
+			the biggest page here.
+		</p>
+		<Gallery />
+	</div>
+);
+
+export default GalleryPage;

--- a/site/yarn.lock
+++ b/site/yarn.lock
@@ -59,17 +59,24 @@
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.1.1.tgz#9daf5745156fd84b8e9889a2dc721f0c58e894aa"
   integrity sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw==
 
-"@moai/core@1.0.0-rc7":
-  version "1.0.0-rc7"
-  resolved "https://registry.yarnpkg.com/@moai/core/-/core-1.0.0-rc7.tgz#9076e781db7b031585ecc2389656ff9e66b7291e"
-  integrity sha512-SvemL7mPb1JtSfMQPs7xqC5kE0yBFEZMx5SThi8RhHdLnyUuaLusjmZsv4S5n9ztzugsWDYP5LhBgXQK9rKafA==
+"@moai/core@1.0.0-rc10":
+  version "1.0.0-rc10"
+  resolved "https://registry.yarnpkg.com/@moai/core/-/core-1.0.0-rc10.tgz#d7112620df4ffe7dddd83b9d6b8db1be805fea8b"
+  integrity sha512-Fgc4eGFjw954kw9rQt3h6E8ElH5aTJC+gBXVFkPibv4CPajypdDMYD3e56vp2D/iFNyyLWV69GzWckrul47Hkw==
   dependencies:
-    "@popperjs/core" "2.9.2"
-    "@tippyjs/react" "4.2.5"
-    react-day-picker "7.4.10"
-    react-hot-toast "1.0.2"
-    react-icons "4.2.0"
-    react-popper "2.2.5"
+    "@popperjs/core" "^2.9.2"
+    "@tippyjs/react" "^4.2.5"
+    react-day-picker "^7.4.10"
+    react-hot-toast "^1.0.2"
+    react-icons "^4.2.0"
+    react-popper "^2.2.5"
+
+"@moai/gallery@1.0.0-rc11":
+  version "1.0.0-rc11"
+  resolved "https://registry.yarnpkg.com/@moai/gallery/-/gallery-1.0.0-rc11.tgz#223259707c63f8a82e00d92801adee7fd26923eb"
+  integrity sha512-wE04OGJ+DDPkWRCv3LdjdrIl1FiobpwnCZvz9mEU2nlcHyKTCqnoArR7sLHUOcrxfm+Ej/x0fXpuzUKj+Yus6g==
+  dependencies:
+    tslib "^2.2.0"
 
 "@next/env@10.2.0":
   version "10.2.0"
@@ -115,17 +122,17 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/context-base/-/context-base-0.14.0.tgz#c67fc20a4d891447ca1a855d7d70fa79a3533001"
   integrity sha512-sDOAZcYwynHFTbLo6n8kIbLiVF3a3BLkrmehJUyEbT9F+Smbi47kLGS2gG2g0fjBLR/Lr1InPD7kXL7FaTqEkw==
 
-"@popperjs/core@2.9.2":
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
-  integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
-
 "@popperjs/core@^2.8.3":
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.0.tgz#32e63212293dd3efbb521cd35a5020ab66eaa546"
   integrity sha512-wjtKehFAIARq2OxK8j3JrggNlEslJfNuSm2ArteIbKyRMts2g0a7KzTxfRVNUM+O0gnBJ2hNV8nWPOYBgI1sew==
 
-"@tippyjs/react@4.2.5":
+"@popperjs/core@^2.9.2":
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
+  integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
+
+"@tippyjs/react@^4.2.5":
   version "4.2.5"
   resolved "https://registry.yarnpkg.com/@tippyjs/react/-/react-4.2.5.tgz#9b5837db93a1cac953962404df906aef1a18e80d"
   integrity sha512-YBLgy+1zznBNbx4JOoOdFXWMLXjBh9hLPwRtq3s8RRdrez2l3tPBRt2m2909wZd9S1KUeKjOOYYsnitccI9I3A==
@@ -137,10 +144,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.41.tgz#d0b939d94c1d7bd53d04824af45f1139b8c45615"
   integrity sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g==
 
-"@types/node@15.0.2":
-  version "15.0.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.0.2.tgz#51e9c0920d1b45936ea04341aa3e2e58d339fb67"
-  integrity sha512-p68+a+KoxpoB47015IeYZYRrdqMUcpbK8re/zpFB8Ld46LHC1lPEbp3EXgkEhAYEcPvjJF6ZO+869SQ0aH1dcA==
+"@types/node@15.3.0":
+  version "15.3.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.3.0.tgz#d6fed7d6bc6854306da3dea1af9f874b00783e26"
+  integrity sha512-8/bnjSZD86ZfpBsDlCIkNXIvm+h6wi9g7IqL+kmFkQ+Wvu3JrasgLElfiPgoo8V8vVfnEi0QVS12gbl94h9YsQ==
 
 "@types/prop-types@*":
   version "15.7.3"
@@ -1474,7 +1481,7 @@ raw-body@2.4.1:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-react-day-picker@7.4.10:
+react-day-picker@^7.4.10:
   version "7.4.10"
   resolved "https://registry.yarnpkg.com/react-day-picker/-/react-day-picker-7.4.10.tgz#d3928fa65c04379ad28c76de22aa85374a8361e1"
   integrity sha512-/QkK75qLKdyLmv0kcVzhL7HoJPazoZXS8a6HixbVoK6vWey1Od1WRLcxfyEiUsRfccAlIlf6oKHShqY2SM82rA==
@@ -1495,14 +1502,14 @@ react-fast-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
-react-hot-toast@1.0.2:
+react-hot-toast@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/react-hot-toast/-/react-hot-toast-1.0.2.tgz#162f020ba7c0b20f2f25bb7738458c435e84107c"
   integrity sha512-wp89H0WA6EtiexAg5l3ys+WaZ3u0xM/FJWxl6YxR3hlquWhKvO9snBgTe4ATPEcgbS6pbc43RbuBINOkYOzA5A==
   dependencies:
     goober "^2.0.15"
 
-react-icons@4.2.0:
+react-icons@4.2.0, react-icons@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.2.0.tgz#6dda80c8a8f338ff96a1851424d63083282630d0"
   integrity sha512-rmzEDFt+AVXRzD7zDE21gcxyBizD/3NqjbX6cmViAgdqfJ2UiLer8927/QhhrXQV7dEj/1EGuOTPp7JnLYVJKQ==
@@ -1512,7 +1519,7 @@ react-is@16.13.1, react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-popper@2.2.5:
+react-popper@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.5.tgz#1214ef3cec86330a171671a4fbcbeeb65ee58e96"
   integrity sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==
@@ -1833,6 +1840,11 @@ ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
+
+tslib@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
+  integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
This PR fixes #150, making @moai/core completely tree-shaking-able! Note that this PR alone doesn't "fix" the tree-shaking issue, but it is based on top of the heavy work of #181.

The tree-shaking can be tested right in the "site" project, with pages under the "/tests":

```
├ ○ /tests/empty          364 B          68.8 kB // base of nextjs
├ ○ /tests/button         2.7 kB         71.1 kB // import only Button
├ ○ /tests/gallery        397 B           117 kB // import the whole gallery
└ ○ /tests/dynamic        3.15 kB        71.6 kB // import the whole gallery dynamically
```