### PR TITLE
Feat(core): Support expandable prop in Table

### DIFF
--- a/lib/core/src/table/cell/cell.tsx
+++ b/lib/core/src/table/cell/cell.tsx
@@ -23,12 +23,12 @@ export const TableCell = <R,>(props: Props<R>): JSX.Element => {
 			: row[column.render]; // Accessor
 	const children = (() => {
 		if (index !== 0) return body;
-		if (table.expandRowRender === undefined) return body;
+		if (table.expandable === undefined) return body;
 		return <TableCellExpand {...{ state, rowKey }} children={body} />;
 	})();
 	const className = [
 		border.weak,
-		state.expanded.has(rowKey) ? background.weak : background.strong,
+		state.expandable.expanded.has(rowKey) ? background.weak : background.strong,
 		column.className,
 	].join(" ");
 	return <td className={className} children={children} />;

--- a/lib/core/src/table/cell/cell.tsx
+++ b/lib/core/src/table/cell/cell.tsx
@@ -28,7 +28,9 @@ export const TableCell = <R,>(props: Props<R>): JSX.Element => {
 	})();
 	const className = [
 		border.weak,
-		state.expandable.expanded.has(rowKey) ? background.weak : background.strong,
+		state.expandable.expanded.has(rowKey)
+			? background.weak
+			: background.strong,
 		column.className,
 	].join(" ");
 	return <td className={className} children={children} />;

--- a/lib/core/src/table/cell/expand/expand.tsx
+++ b/lib/core/src/table/cell/expand/expand.tsx
@@ -14,13 +14,13 @@ interface Props {
 /** Add a toggle button to first cell of an expandable row */
 export const TableCellExpand = (props: Props): JSX.Element => {
 	const { state, rowKey, children } = props;
-	const expanded = state.expanded.has(rowKey);
+	const expanded = state.expandable.expanded.has(rowKey);
 	const icon = expanded ? coreIcons.chevronUp : coreIcons.chevronDown;
 	return (
 		<div className={s.container}>
 			<div className={s.child}>
 				<Button
-					onClick={() => state.setExpanded(rowKey, !expanded)}
+					onClick={() => state.expandable.setExpanded(rowKey, !expanded)}
 					icon={icon}
 					iconLabel="Expand/collapse row"
 					size={Button.sizes.smallIcon}

--- a/lib/core/src/table/cell/expand/expand.tsx
+++ b/lib/core/src/table/cell/expand/expand.tsx
@@ -16,11 +16,12 @@ export const TableCellExpand = (props: Props): JSX.Element => {
 	const { state, rowKey, children } = props;
 	const expanded = state.expandable.expanded.has(rowKey);
 	const icon = expanded ? coreIcons.chevronUp : coreIcons.chevronDown;
+	const toggle = () => state.expandable.setExpanded(rowKey, !expanded);
 	return (
 		<div className={s.container}>
 			<div className={s.child}>
 				<Button
-					onClick={() => state.expandable.setExpanded(rowKey, !expanded)}
+					onClick={toggle}
 					icon={icon}
 					iconLabel="Expand/collapse row"
 					size={Button.sizes.smallIcon}

--- a/lib/core/src/table/expandable.ts
+++ b/lib/core/src/table/expandable.ts
@@ -1,0 +1,58 @@
+import * as React from "react";
+
+export interface TableExpandableProps<R> {
+	/**
+	 * A [render prop][1] that should return the React node to be rendered in
+	 * the expanded area the given row.
+	 *
+	 * [1]: https://reactjs.org/docs/render-props.html
+	 */
+	render: (row: R) => React.ReactNode;
+	/**
+	 * List of key of expanded rows, for controlled usage.
+	 */
+	expanded?: Set<string>;
+	/**
+	 * Callback to set expanded rows, for controlled usage.
+	 */
+	setExpanded?: React.Dispatch<React.SetStateAction<Set<string>>>;
+	/**
+	 * Initial expanded rows, for uncontrolled usage.
+	 */
+	initialExpanded?: Set<string>;
+}
+
+export interface TableExpandableState {
+	expanded: Set<string>;
+	// Note that this is not the setter from React's state but an easier-to-use
+	// version that works on each row.
+	setExpanded: (key: string, expanded: boolean) => void;
+}
+
+type Props<R> = TableExpandableProps<R>;
+type State = TableExpandableState;
+
+export const useTableExpandable = <R>(props?: Props<R>): State => {
+	const internal = React.useState(() => {
+		return props?.initialExpanded ?? new Set<string>();
+	});
+
+	const value: State["expanded"] = props?.expanded ?? internal[0];
+
+	// The original internal setter that set the whole "expanded" state
+	const setExpanded = props?.setExpanded ?? internal[1];
+
+	// A easier-to-use public setter that set row by row
+	const setValue: State["setExpanded"] = React.useCallback(
+		(key: string, expanded: boolean) => {
+			setExpanded((prev) => {
+				const next = new Set(prev);
+				expanded ? next.add(key) : next.delete(key);
+				return next;
+			});
+		},
+		[setExpanded]
+	);
+
+	return { expanded: value, setExpanded: setValue };
+};

--- a/lib/core/src/table/row/row.tsx
+++ b/lib/core/src/table/row/row.tsx
@@ -4,7 +4,7 @@ import { TableCell } from "../cell/cell";
 import { TableColumn, TableProps, TableState } from "../table";
 
 const ERRORS = {
-	EXPAND_RENDER: "Row is expanded but expandRowRender is not defined.",
+	EXPAND_RENDER: "Row is expanded but expanded.render is not defined.",
 };
 
 interface Props<R> {
@@ -28,7 +28,7 @@ const renderTd = <R,>(
 
 const FullCell = <R,>(props: Props<R>): JSX.Element => {
 	const { table, row } = props;
-	const render = table.expandRowRender;
+	const render = table.expandable?.render;
 	if (render === undefined) throw Error(ERRORS.EXPAND_RENDER);
 	return (
 		<td
@@ -45,7 +45,7 @@ export const getTableRow = <R,>(props: Props<R>): JSX.Element[] => {
 
 	const cells = table.columns.map(renderTd(table, state, row, index));
 	const mainTr = <tr key={key} children={cells} />;
-	if (state.expanded.has(key) === false) return [mainTr];
+	if (state.expandable.expanded.has(key) === false) return [mainTr];
 
 	// Expanded
 	const cell = <FullCell {...props} />;

--- a/lib/core/src/table/table.tsx
+++ b/lib/core/src/table/table.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useState } from "react";
+import { ReactNode } from "react";
 import { background } from "../background/background";
 import { border } from "../border/border";
 import { text } from "../text/text";
@@ -6,6 +6,11 @@ import sFixed from "./fixed.module.css";
 import sSizes from "./sizes.module.css";
 import { getTableRow } from "./row/row";
 import s from "./table.module.css";
+import {
+	TableExpandableProps,
+	TableExpandableState,
+	useTableExpandable,
+} from "./expandable";
 
 export interface TableColumn<R> {
 	/**
@@ -63,13 +68,10 @@ export interface TableProps<R> {
 	 */
 	columns: TableColumn<R>[];
 	/**
-	 * A [render prop][1] that, when set, allows users to expand or collapse
-	 * the table's rows. This should return the React element to be rendered
-	 * when a row is expanded.
-	 *
-	 * [1]: https://reactjs.org/docs/render-props.html
+	 * If defined, each row has a button for users to expand the row. See the
+	 * "TableExpandedProps" interface for detail.
 	 */
-	expandRowRender?: (row: R) => ReactNode;
+	expandable?: TableExpandableProps<R>;
 	/**
 	 * If true, the table's header, first column and last column can be fixed
 	 * while the rest is scrolled. These positions are relative to the table's
@@ -95,8 +97,7 @@ const renderTh = <R,>(column: TableColumn<R>, index: number): JSX.Element => (
 );
 
 export interface TableState {
-	expanded: Set<string>;
-	setExpanded: (key: string, value: boolean) => void;
+	expandable: TableExpandableState;
 }
 
 /**
@@ -109,15 +110,8 @@ export interface TableState {
  * [3]: #fixed
  */
 export const Table = <R,>(props: TableProps<R>): JSX.Element => {
-	const [expanded, _setExpanded] = useState(() => new Set<string>());
-	const setExpanded: TableState["setExpanded"] = (key, value) => {
-		_setExpanded((prev) => {
-			const next = new Set(prev);
-			value ? next.add(key) : next.delete(key);
-			return next;
-		});
-	};
-	const state = { expanded, setExpanded };
+	const expandable = useTableExpandable(props.expandable);
+	const state: TableState = { expandable };
 
 	const body: JSX.Element[] = [];
 	props.rows.forEach((row, index) => {

--- a/lib/docs/src/components/table-fake.tsx
+++ b/lib/docs/src/components/table-fake.tsx
@@ -1,4 +1,5 @@
 import { TableColumn } from "../../../core/src";
+import { TableExpandableProps } from "../../../core/src/table/expandable";
 
 /**
  * This is not a part of the source code. It exists only for Storybook's
@@ -7,3 +8,7 @@ import { TableColumn } from "../../../core/src";
 export const TableColumnComponent = <R,>(
 	props: TableColumn<R>
 ): JSX.Element => <div>{props.title}</div>;
+
+export const TableExpandableComponent = <R,>(
+	props: TableExpandableProps<R>
+): JSX.Element => <div>{props.render.length}</div>;

--- a/lib/docs/src/components/table.stories.tsx
+++ b/lib/docs/src/components/table.stories.tsx
@@ -2,22 +2,25 @@ import { Meta } from "@storybook/react";
 import { Pane, Table, TableColumn } from "../../../core/src";
 import { Robot, ROBOTS } from "../../../gallery/src/table/robots";
 import { GalleryTable } from "../../../gallery/src/table/table";
-import { TableColumnComponent } from "./table-fake";
+import { TableColumnComponent, TableExpandableComponent } from "./table-fake";
 import { Utils } from "../utils/utils";
 import { Book, someBooks } from "../utils/example";
 
 const meta: Meta = {
 	title: "Components/Table",
 	component: Table,
-	subcomponents: { TableColumn: TableColumnComponent },
+	subcomponents: {
+		TableColumn: TableColumnComponent,
+		TableExpandable: TableExpandableComponent,
+	},
 	argTypes: {
 		fill: Utils.arg("boolean"),
 		size: Utils.arg(Table.sizes),
+		fixed: Utils.arg(null),
 		rows: Utils.arg(null),
 		rowKey: Utils.arg(null),
 		columns: Utils.arg(null),
-		expandRowRender: Utils.arg(null),
-		fixed: Utils.arg(null),
+		expandable: Utils.arg(null),
 	},
 };
 
@@ -216,16 +219,33 @@ export const Expandable = (): JSX.Element => (
 		rows={someBooks}
 		rowKey={bookKey}
 		columns={bookColumns}
-		expandRowRender={(row) => row.isbn}
+		expandable={{ render: (row) => row.isbn }}
 	/>
 );
 
 Utils.story(Expandable, {
 	desc: `
-Users can expand a table's rows if the \`expandRowRender\` prop is provided.
-It expects a function that returns what to be rendered in the expanded area of
-a row. The expanded area is below a row, spanning all columns (i.e. similar to
-a \`td\` with \`colSpan\` set to the number of columns).
+If the \`expandable\` prop is defined, each row will have a button for users to
+expand it. It only requires a \`render\` function that returns what to be
+rendered when the given row is expanded.
+
+~~~ts
+interface TableExpandable {
+	render: (row: R) => ReactNode;
+	initialExpanded?: Set<string>;
+	expanded?: Set<string>;
+	setExpanded?: (set: Set<string>) => void;
+}
+~~~
+
+Other properties are optional and help you set the initial expanded rows, or
+even control the state yourself. They all work on a [Set][1] of [row keys][2].
+See the [TableExpandable][3] table at the end of the page for detail of each
+prop.
+
+[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set
+[2]: #basic
+[3]: #props
 `,
 });
 

--- a/lib/gallery/src/table/table.tsx
+++ b/lib/gallery/src/table/table.tsx
@@ -154,7 +154,7 @@ export const GalleryTable = (): JSX.Element => (
 					rows={ROBOTS}
 					columns={getColumns()}
 					rowKey={(robot) => robot.id}
-					expandRowRender={(robot) => <Note robot={robot} />}
+					expandable={{ render: (robot) => <Note robot={robot} /> }}
 					fixed={{ header: true, firstColumn: true }}
 				/>
 			</div>


### PR DESCRIPTION
This adds more advanced usage to the expandable ability of Table, such as initial state or controlled state

See: https://moai-docs-git-fork-thien-do-table-expandable-makeinvietnam.vercel.app/?path=/docs/components-table--expandable