### PR TITLE
Feat(core): Support checkbox and radio without label

### DIFF
--- a/lib/core/src/checkbox/checkbox.tsx
+++ b/lib/core/src/checkbox/checkbox.tsx
@@ -6,6 +6,7 @@ import self from "./checkbox.module.css";
 import shared from "./shared.module.css";
 import outset from "./outset.module.css";
 import { border } from "../border/border";
+import { utilStyles } from "../utils/utils";
 
 interface CheckboxStyle {
 	input: string;
@@ -49,9 +50,25 @@ export interface CheckboxProps {
 	// Body
 
 	/**
-	 * The label of the checkbox.
+	 * The label of the checkbox. This accepts ReactNode so you can have custom
+	 * markup.
+	 *
+	 * We intentionally exclude the falsy values here (e.g. "null", "false").
+	 * To ensure good accessibility, always define a label for your checkbox,
+	 * even if you don't want to display it (see the "hideLabel" prop).
 	 */
-	children: React.ReactNode;
+	children: Exclude<React.ReactNode, null | false | undefined>;
+	/**
+	 * Hide the label visually, but still leaving it accessible for screen
+	 * readers. For sighted users, this displays just the box. For unsighted,
+	 * it works like a normal checkbox.
+	 *
+	 * See the [`selectable`][1] prop of the Table component for a real-life
+	 * example.
+	 *
+	 * [1]: /docs/components-table--selectable-multiple
+	 */
+	hideLabel?: boolean;
 	/**
 	 * The [HTML `disabled`][1] attribute of the underlying input element. If
 	 * set to `true`, this prevents users from interacting with the checkbox.
@@ -134,12 +151,14 @@ export const Checkbox = (props: CheckboxProps): JSX.Element => {
 				)}
 				children={<Icon display="block" component={coreIcons.dash} />}
 			/>
-			{props.children !== null && (
-				<span
-					className={[shared.label, style.label].join(" ")}
-					children={props.children}
-				/>
-			)}
+			<span
+				className={[
+					shared.label,
+					style.label,
+					props.hideLabel ? utilStyles.srOnly : "",
+				].join(" ")}
+				children={props.children}
+			/>
 		</label>
 	);
 };

--- a/lib/core/src/radio/radio.tsx
+++ b/lib/core/src/radio/radio.tsx
@@ -1,10 +1,11 @@
-import { ForwardedRef, ReactNode } from "react";
-import { Icon } from "../icon/icon";
-import { outline } from "../outline/outline";
-import self from "./radio.module.css";
-import shared from "../checkbox/shared.module.css";
-import { coreIcons } from "../icons/icons";
+import { ForwardedRef } from "react";
 import { Checkbox } from "../checkbox/checkbox";
+import shared from "../checkbox/shared.module.css";
+import { Icon } from "../icon/icon";
+import { coreIcons } from "../icons/icons";
+import { outline } from "../outline/outline";
+import { utilStyles } from "../utils/utils";
+import self from "./radio.module.css";
 
 export interface RadioProps {
 	/**
@@ -23,9 +24,25 @@ export interface RadioProps {
 	 */
 	value: string;
 	/**
-	 * The label for the radio.
+	 * The label of the checkbox. This accepts ReactNode so you can have custom
+	 * markup.
+	 *
+	 * We intentionally exclude the falsy values here (e.g. "null", "false").
+	 * To ensure good accessibility, always define a label for your checkbox,
+	 * even if you don't want to display it (see the "hideLabel" prop).
 	 */
-	children: ReactNode;
+	children: Exclude<React.ReactNode, null | false | undefined>;
+	/**
+	 * Hide the label visually, but still leaving it accessible for screen
+	 * readers. For sighted users, this displays just the box. For unsighted,
+	 * it works like a normal checkbox.
+	 *
+	 * See the [`selectable`][1] prop of the Table component for a real-life
+	 * example.
+	 *
+	 * [1]: /docs/components-table--selectable-multiple
+	 */
+	hideLabel?: boolean;
 	/**
 	 * The [HTML `disabled`][1] attribute. If true, it prevents users from
 	 * interacting with the radio button.
@@ -86,12 +103,14 @@ export const Radio = (props: RadioProps): JSX.Element => {
 			<span className={[shared.icon, style.icon, self.icon].join(" ")}>
 				<Icon display="block" component={coreIcons.dot} />
 			</span>
-			{props.children !== null && (
-				<span
-					className={[shared.label, style.label].join(" ")}
-					children={props.children}
-				/>
-			)}
+			<span
+				className={[
+					shared.label,
+					style.label,
+					props.hideLabel ? utilStyles.srOnly : "",
+				].join(" ")}
+				children={props.children}
+			/>
 		</label>
 	);
 };

--- a/lib/core/src/table/actions/selectable/control.tsx
+++ b/lib/core/src/table/actions/selectable/control.tsx
@@ -23,7 +23,8 @@ const SelectableCheckbox = (props: PropsMultiple): JSX.Element => {
 		<Checkbox
 			checked={selected.has(rowKey)}
 			setChecked={setChecked}
-			children={null}
+			children={`Select ${rowKey}`}
+			hideLabel
 		/>
 	);
 };
@@ -39,7 +40,8 @@ const SelectableRadio = (props: PropsSingle): JSX.Element => {
 			checked={selected === rowKey}
 			value={rowKey}
 			setValue={setSelected}
-			children={null}
+			children={`Select ${rowKey}`}
+			hideLabel
 		/>
 	);
 };

--- a/lib/core/src/utils/utils.module.css
+++ b/lib/core/src/utils/utils.module.css
@@ -1,0 +1,9 @@
+/* https://webaim.org/techniques/css/invisiblecontent/#offscreen */
+.srOnly {
+	position: absolute;
+	left: -10000px;
+	top: auto;
+	width: 1px;
+	height: 1px;
+	overflow: hidden;
+}

--- a/lib/core/src/utils/utils.ts
+++ b/lib/core/src/utils/utils.ts
@@ -1,4 +1,5 @@
 import { Dispatch, SetStateAction } from "react";
+import s from "./utils.module.css";
 
 const portalContainer: { current: null | HTMLElement } = { current: null };
 
@@ -12,3 +13,7 @@ export const getPortalContainer = (): HTMLElement => {
 };
 
 export type SetState<T> = Dispatch<SetStateAction<T>>;
+
+export const utilStyles = {
+	srOnly: s.srOnly,
+};

--- a/lib/docs/src/components/checkbox.stories.tsx
+++ b/lib/docs/src/components/checkbox.stories.tsx
@@ -50,9 +50,7 @@ export const Basic = (): JSX.Element => {
 
 Utils.story(Basic, {
 	desc: `
-Checkbox is a [controlled][1] component. You should have a boolean [state][2]
-for the checked state, and give its control to a checkbox via the \`checked\`
-and \`setChecked\` props.
+Checkbox is a [controlled][1] component. You should have a boolean [state][2] for the checked state, and give its control to a checkbox via the \`checked\` and \`setChecked\` props.
 
 [1]: https://reactjs.org/docs/forms.html#controlled-components
 [2]: https://reactjs.org/docs/hooks-state.html
@@ -77,11 +75,8 @@ export const IndeterminateImperative = (): JSX.Element => {
 
 Utils.story(IndeterminateImperative, {
 	name: "Indeterminate (Imperative)",
-
 	desc: `
-Moai checkboxes support the [indeterminate][1] state. It's recommended to set
-this state in JavaScript, like when using the HTML \`checkbox\`. This is done
-by having a [reference][2] to the checkbox via the \`forwardedRef\`.
+Moai checkboxes support the [indeterminate][1] state. It's recommended to set this state in JavaScript, like when using the HTML \`checkbox\`. This is done by having a [reference][2] to the checkbox via the \`forwardedRef\`.
 
 [1]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#indeterminate_state_checkboxes
 [2]: https://reactjs.org/docs/refs-and-the-dom.html
@@ -94,12 +89,8 @@ export const IndeterminateDeclarative = (): JSX.Element => (
 
 Utils.story(IndeterminateDeclarative, {
 	name: "Indeterminate (Declarative)",
-
 	desc: `
-Moai also supports having the indeterminate state delacratively, via the
-\`indeterminate\` prop, where it does [the imperative work][1] for you.
-However, this should be considered experimental. See the [List][2] section
-below for a full example.
+Moai also supports having the indeterminate state delacratively, via the \`indeterminate\` prop, where it does [the imperative work][1] for you.  However, this should be considered experimental. See the [List][2] section below for a full example.
 
 [1]: https://github.com/moaijs/moai/blob/5ff5ee97d594954b160b375a984e9f44bfb34f9a/lib/core/src/checkbox/checkbox.tsx#L69-L74
 [2]: #list
@@ -146,10 +137,24 @@ export const Group = (): JSX.Element => {
 
 Utils.story(Group, {
 	desc: `
-To have a group of checkboxes, render them with \`map\` and \`key\` [as
-usual][1]. The type of your state is up to you: a \`Map\` of boolean values, a
-\`Set\` of ids, or just an array:
+To have a group of checkboxes, render them with \`map\` and \`key\` [as usual][1]. The type of your state is up to you: a \`Map\` of boolean values, a \`Set\` of ids, or just an array:
 
 [1]: https://reactjs.org/docs/lists-and-keys.html
+`,
+});
+
+export const WithoutLabel = (): JSX.Element => (
+	<Checkbox hideLabel>Sample checkbox</Checkbox>
+);
+
+Utils.story(WithoutLabel, {
+	desc: `
+The \`children\` prop of Checkbox accepts \`ReactNode\` but intentionally excludes the falsy values (e.g. \`false\`, \`null\`, \`undefined\`). This ensures your checkboxes always have accessible labels, even if the labels are not _displayed_.
+
+To hide the label of a checkbox, set its \`hideLabel\` prop to \`true\`. You'll still need to define a label at the \`children\` prop. Sighted users won't see the label, but screen readers will announce it for unsighted users.
+
+This should be used where the surrounding context can visually tell your sighted users about the meaning of the checkboxes. A common use case is to have a checkbox for each row of a table. In fact, for a real-life example, see the [\`selectable\`][1] section of the Table component.
+
+[1]: /docs/components-table--selectable-multiple
 `,
 });

--- a/lib/docs/src/components/radio.stories.tsx
+++ b/lib/docs/src/components/radio.stories.tsx
@@ -61,10 +61,7 @@ export const Basic = (): JSX.Element => {
 
 Utils.story(Basic, {
 	desc: `
-It's recommended to use the [Radio Group][1] component. However, when you need
-complex layout customization, you can still use the Radio component manually.
-It should be used as a controlled component, but its props are a little bit
-more complicated than other input components:
+It's recommended to use the [Radio Group][1] component. However, when you need complex layout customization, you can still use the Radio component manually.  It should be used as a controlled component, but its props are a little bit more complicated than other input components:
 
 - \`checked\`: whether the radio should be checked
 - \`value\`: the text value of the radio
@@ -73,5 +70,23 @@ more complicated than other input components:
 Like in HTML, a \`name\` prop is also required to group your radio buttons.
 
 [1]: /docs/components-radio-group--primary
+`,
+});
+
+export const WithoutLabel = (): JSX.Element => (
+	<Radio name="radio" value="1" hideLabel>
+		Sample Radio
+	</Radio>
+);
+
+Utils.story(WithoutLabel, {
+	desc: `
+The \`children\` prop of Radio accepts \`ReactNode\` but intentionally excludes the falsy values (e.g. \`false\`, \`null\`, \`undefined\`). This ensures your radio buttons always have accessible labels, even if the labels are not _displayed_.
+
+To hide the label of a radio button, set its \`hideLabel\` prop to \`true\`.  You'll still need to define a label at the \`children\` prop. Sighted users won't see the label, but screen readers will announce it for unsighted users.
+
+This should be used where the surrounding context can visually tell your sighted users about the meaning of the radio buttons. A common use case is to have a radio button for each row of a table. In fact, for a real-life example, see the [\`selectable\`][1] section of the Table component.
+
+[1]: /docs/components-table--selectable-single
 `,
 });


### PR DESCRIPTION
Previously (in #215 to be specific), Checkbox and Radio did support usage without label by accepting a "null" children. However, it's pretty bad accessibility-wise, since the elements will have literally no label. A sighted user can usually still understand what do they control, but it's much harder for unsighted ones.

This PR fixes that by excluding falsy values (null, undefined) in the children prop, and instead having a "hideLabel" prop, which would hide the label correctly: sighted users won't see it, but screen readers will. The labels are, therefore, always required.

See:
- https://moai-docs-git-fork-thien-do-without-label-makeinvietnam.vercel.app/?path=/docs/components-checkbox--without-label
- https://moai-docs-git-fork-thien-do-without-label-makeinvietnam.vercel.app/?path=/docs/components-radio--without-label