### PR TITLE
Build: Use distribution in Docs

### DIFF
--- a/.github/DEVELOP.md
+++ b/.github/DEVELOP.md
@@ -12,12 +12,16 @@ To understand the principles that drive the design and development of Moai, see 
 
 ## Codebase overview
 
+Moai is a [monorepo](https://classic.yarnpkg.com/en/docs/workspaces/) powered by Yarn. There are several projects:
+
 | Path    | Project           | Framework   |
 | ------- | ----------------- | ----------- |
 | core    | [@moai/core]      | [Rollup]    |
 | gallery | [@moai/gallery]   | [Rollup]    |
 | docs    | [docs.moaijs.com] | [Storybook] |
 | test    | Test suits        | [Jest]      |
+
+The "test" and "docs" projects depend on "core" and "gallery" via symlinks. This means to run tests or start the docs site locally, you will need to start or build "core" and "gallery" first.
 
 [@moai/core]: https://www.npmjs.com/package/@moai/core
 [@moai/gallery]: https://www.npmjs.com/package/@moai/gallery
@@ -29,11 +33,13 @@ To understand the principles that drive the design and development of Moai, see 
 
 ## Development scripts
 
--   `yarn core`: watch and build @moai/core
--   `yarn docs`: start docs.moaijs.com locally
+-   `yarn start-core`: watch and build @moai/core
+-   `yarn start-gallery`: watch and build @moai/gallery
+-   `yarn start-docs`: start docs.moaijs.com locally
 -   `yarn test`: run the test suites
 
-"docs" and "test" both rely on the output of "core"'s build, so in most cases you will need:
+The full workflow is to have 4 terminal tabs, one for each command above. However, depend on your use cases, it may be simpler:
 
--   a terminal to run `yarn core`, and
--   a terminal to run `yarn docs` or `yarn test`
+If you'd like to work on tests or docs, you don't need to start the "core" and "gallery", but only need to build them once using `yarn build-core` and `yarn build-gallery`. Then, you can `yarn start-docs` or `yarn test`.
+
+If you'd like to work on the "core" project, which should be most of the time, then you don't need to start the "gallery" but only need to build them once using `yarn build-gallery`.

--- a/.github/DEVELOP.md
+++ b/.github/DEVELOP.md
@@ -33,13 +33,13 @@ The "test" and "docs" projects depend on "core" and "gallery" via symlinks. This
 
 ## Development scripts
 
--   `yarn start-core`: watch and build @moai/core
--   `yarn start-gallery`: watch and build @moai/gallery
--   `yarn start-docs`: start docs.moaijs.com locally
+-   `yarn watch:core`: watch and build @moai/core
+-   `yarn watch:gallery`: watch and build @moai/gallery
+-   `yarn start:docs`: start docs.moaijs.com locally
 -   `yarn test`: run the test suites
 
 The full workflow is to have 4 terminal tabs, one for each command above. However, depend on your use cases, it may be simpler:
 
-If you'd like to work on tests or docs, you don't need to start the "core" and "gallery", but only need to build them once using `yarn build-core` and `yarn build-gallery`. Then, you can `yarn start-docs` or `yarn test`.
+If you'd like to work on tests or docs, you don't need to start the "core" and "gallery", but only need to build them once using `yarn build:npm`. Then, you can `yarn start:docs` or `yarn test`.
 
-If you'd like to work on the "core" project, which should be most of the time, then you don't need to start the "gallery" but only need to build them once using `yarn build-gallery`.
+If you'd like to work on the "core" project, which should be most of the time, then you don't need to start the "gallery" but only need to build them once using `yarn build:npm:gallery`.

--- a/.github/DEVELOP.md
+++ b/.github/DEVELOP.md
@@ -21,7 +21,18 @@ Moai is a [monorepo](https://classic.yarnpkg.com/en/docs/workspaces/) powered by
 | docs    | [docs.moaijs.com] | [Storybook] |
 | test    | Test suits        | [Jest]      |
 
-The "test" and "docs" projects depend on "core" and "gallery" via symlinks. This means to run tests or start the docs site locally, you will need to start or build "core" and "gallery" first.
+The "test" and "docs" projects depend on "core" and "gallery" via symlinks. This means to run tests or start the docs site locally, you will need to build "core" and "gallery" first. Also, the "gallery" depends on the "core" project:
+
+```
+├─ docs
+│    ├─ gallery
+│    └─ core
+├─ test
+│    └─ core
+├─ gallery
+│    └─ core
+└─ core
+```
 
 [@moai/core]: https://www.npmjs.com/package/@moai/core
 [@moai/gallery]: https://www.npmjs.com/package/@moai/gallery
@@ -33,13 +44,11 @@ The "test" and "docs" projects depend on "core" and "gallery" via symlinks. This
 
 ## Development scripts
 
--   `yarn watch:core`: watch and build @moai/core
--   `yarn watch:gallery`: watch and build @moai/gallery
--   `yarn start:docs`: start docs.moaijs.com locally
+-   `yarn start-core`: watch and build @moai/core
+-   `yarn start-gallery`: watch and build @moai/gallery
+-   `yarn start-docs`: start docs.moaijs.com locally
 -   `yarn test`: run the test suites
 
-The full workflow is to have 4 terminal tabs, one for each command above. However, depend on your use cases, it may be simpler:
+The typical workflow is to have 4 terminal tabs, one for each command above. However, depend on your use cases, you may not need to "watch" some projects, but only "build" them once.
 
-If you'd like to work on tests or docs, you don't need to start the "core" and "gallery", but only need to build them once using `yarn build:npm`. Then, you can `yarn start:docs` or `yarn test`.
-
-If you'd like to work on the "core" project, which should be most of the time, then you don't need to start the "gallery" but only need to build them once using `yarn build:npm:gallery`.
+Note the dependency of these projects. In general, start "core" first, then "gallery", then "docs".

--- a/core/package.json
+++ b/core/package.json
@@ -11,7 +11,7 @@
 	],
 	"scripts": {
 		"build": "rollup --config",
-		"start": "rollup --config --watch",
+		"watch": "rollup --config --watch",
 		"report": "node ./scripts/report.js",
 		"prepublishOnly": "yarn build"
 	},

--- a/core/src/table/table.tsx
+++ b/core/src/table/table.tsx
@@ -19,6 +19,8 @@ import { TableHead } from "./head/head";
 import sSizes from "./sizes.module.css";
 import s from "./table.module.css";
 
+export type { TableExpandableProps, TableSelectableProps };
+
 export interface TableColumn<R> {
 	/**
 	 * Title of the column. Note that this is not just `string` but

--- a/core/tsconfig.json
+++ b/core/tsconfig.json
@@ -6,5 +6,5 @@
 		"declarationDir": "dist/types",
 		"rootDir": "src"
 	},
-	"include": ["**/*"]
+	"include": ["src/**/*"]
 }

--- a/docs/.storybook/manager.js
+++ b/docs/.storybook/manager.js
@@ -1,7 +1,7 @@
 import { addons } from "@storybook/addons";
 // Use the remote font since the manager is not set up to import local fonts
 // (i.e. woff2 files)
-import "../../core/font/remote.css";
+import "@moai/core/dist/font/remote.css";
 
 addons.setConfig({
 	initialActive: "addons",

--- a/docs/.storybook/preview.js
+++ b/docs/.storybook/preview.js
@@ -1,7 +1,8 @@
 import * as D from "@storybook/addon-docs/blocks";
 import { useDarkMode } from "storybook-dark-mode";
-import "../../core/font/remote.css";
-import "../../core/src/global/global.css";
+import "@moai/core/dist/bundle.css";
+import "@moai/core/dist/font/remote.css";
+import "@moai/gallery/dist/bundle.css";
 import "./preview.css";
 import "./syntax.css";
 import { darkTheme, lightTheme } from "./theme";

--- a/docs/package.json
+++ b/docs/package.json
@@ -21,6 +21,8 @@
 		"@storybook/react": "^6.3.1",
 		"@storybook/theming": "^6.3.1",
 		"@types/color": "^3.0.1",
+		"@moai/core": "*",
+		"@moai/gallery": "*",
 		"autoprefixer": "^10.2.6",
 		"color": "^3.1.3",
 		"formik": "^2.2.9",

--- a/docs/src/color/background/background.tsx
+++ b/docs/src/color/background/background.tsx
@@ -1,4 +1,4 @@
-import { border, background, Table, text } from "../../../../core/src";
+import { border, background, Table, text } from "@moai/core";
 import { ColorSample } from "../sample/sample";
 import s from "./background.module.css";
 

--- a/docs/src/color/border/border.tsx
+++ b/docs/src/color/border/border.tsx
@@ -1,4 +1,4 @@
-import { background, border, Table } from "../../../../core/src";
+import { background, border, Table } from "@moai/core";
 import { ColorSample } from "../sample/sample";
 import s from "./border.module.css";
 

--- a/docs/src/color/category/category.tsx
+++ b/docs/src/color/category/category.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { border, Table } from "../../../../core/src";
-import { GalleryTag } from "../../../../gallery/src/tag";
+import { border, Table } from "@moai/core";
+import { GalleryTag } from "@moai/gallery";
 import s from "./category.module.css";
 
 interface Row {

--- a/docs/src/color/sample/sample.tsx
+++ b/docs/src/color/sample/sample.tsx
@@ -1,7 +1,7 @@
 import Color from "color";
 import { useEffect, useRef, useState } from "react";
 import { HiCheckCircle } from "react-icons/hi";
-import { CategoryColor, categoryColors, Icon, Tag } from "../../../../core/src";
+import { CategoryColor, categoryColors, Icon, Tag } from "@moai/core";
 import s from "./sample.module.css";
 
 export type ColorSampleUsage = "text" | "icon" | "both";

--- a/docs/src/color/static/sample.tsx
+++ b/docs/src/color/static/sample.tsx
@@ -1,6 +1,6 @@
 import Color from "color";
 import { useEffect, useRef, useState } from "react";
-import { text } from "../../../../core/src";
+import { text } from "@moai/core";
 import s from "./sample.module.css";
 
 interface Props {

--- a/docs/src/color/static/table.tsx
+++ b/docs/src/color/static/table.tsx
@@ -1,4 +1,4 @@
-import { border, Table } from "../../../../core/src";
+import { border, Table } from "@moai/core";
 import { ColorStaticSample } from "./sample";
 import s from "./table.module.css";
 

--- a/docs/src/color/text/text.tsx
+++ b/docs/src/color/text/text.tsx
@@ -1,4 +1,4 @@
-import { background, border, Table, text } from "../../../../core/src";
+import { background, border, Table, text } from "@moai/core";
 import { ColorSample, ColorSampleUsage } from "../sample/sample";
 import s from "./text.module.css";
 

--- a/docs/src/components/button-group.stories.tsx
+++ b/docs/src/components/button-group.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/react";
 import { GoSearch } from "react-icons/go";
-import { Button, ButtonGroup, Input, Select } from "../../../core/src";
+import { Button, ButtonGroup, Input, Select } from "@moai/core";
 
 export default {
 	title: "Draft/Button Group",

--- a/docs/src/components/button.stories.tsx
+++ b/docs/src/components/button.stories.tsx
@@ -1,8 +1,8 @@
 import { Meta } from "@storybook/react";
 import { GoPlus } from "react-icons/go";
-import { Button, Dialog } from "../../../core/src";
-import { GalleryButton1 } from "../../../gallery/src/button-1";
-import { GalleryButton2 } from "../../../gallery/src/button-2";
+import { Button, Dialog } from "@moai/core";
+import { GalleryButton1 } from "@moai/gallery";
+import { GalleryButton2 } from "@moai/gallery";
 import { Utils } from "../utils/utils";
 
 const meta: Meta = {

--- a/docs/src/components/checkbox.stories.tsx
+++ b/docs/src/components/checkbox.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/react";
 import { useRef, useState } from "react";
-import { Button, Checkbox } from "../../../core/src";
+import { Button, Checkbox } from "@moai/core";
 import { Book, someBooks } from "../utils/example";
 import { Utils } from "../utils/utils";
 

--- a/docs/src/components/date-input.stories.tsx
+++ b/docs/src/components/date-input.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/react/types-6-0";
 import { useState } from "react";
-import { DateInput } from "../../../core/src";
+import { DateInput } from "@moai/core";
 import { Utils } from "../utils/utils";
 
 const meta: Meta = {

--- a/docs/src/components/dialog.stories.tsx
+++ b/docs/src/components/dialog.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta } from "@storybook/react";
 import { useState } from "react";
-import { Button, Dialog, DivGrow, Paragraph } from "../../../core/src";
-import { GalleryDialog } from "../../../gallery/src/dialog";
+import { Button, Dialog, DivGrow, Paragraph } from "@moai/core";
+import { GalleryDialog } from "@moai/gallery";
 import { Utils } from "../utils/utils";
 
 const meta: Meta = {

--- a/docs/src/components/empty.stories.tsx.bk
+++ b/docs/src/components/empty.stories.tsx.bk
@@ -1,5 +1,5 @@
 import { Meta } from "@storybook/react";
-import { Button, Dialog, EmptyState } from "../../../core/src";
+import { Button, Dialog, EmptyState } from "@moai/core";
 
 
 export default {

--- a/docs/src/components/icon.stories.tsx
+++ b/docs/src/components/icon.stories.tsx
@@ -1,8 +1,8 @@
 import { Meta } from "@storybook/react";
 import { SVGAttributes } from "react";
 import { FaHome } from "react-icons/fa";
-import { Icon, text } from "../../../core/src";
-import { GalleryIcon } from "../../../gallery/src/icon/icon";
+import { Icon, text } from "@moai/core";
+import { GalleryIcon } from "@moai/gallery";
 import { Utils } from "../utils/utils";
 
 const meta: Meta = {

--- a/docs/src/components/input.stories.tsx
+++ b/docs/src/components/input.stories.tsx
@@ -2,9 +2,9 @@ import { Meta } from "@storybook/react";
 import * as Fm from "formik";
 import { useState } from "react";
 import { HiPhone } from "react-icons/hi";
-import { Button, Dialog, DivPx, Input } from "../../../core/src";
-import { GalleryInput1 } from "../../../gallery/src/input-1";
-import { GalleryInput2 } from "../../../gallery/src/input-2";
+import { Button, Dialog, DivPx, Input } from "@moai/core";
+import { GalleryInput1 } from "@moai/gallery";
+import { GalleryInput2 } from "@moai/gallery";
 import { Utils } from "../utils/utils";
 
 const meta: Meta = {

--- a/docs/src/components/pagination.stories.tsx
+++ b/docs/src/components/pagination.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/react";
 import { useCallback, useState } from "react";
-import { Pagination } from "../../../core/src";
+import { Pagination } from "@moai/core";
 import { Utils } from "../utils/utils";
 
 const meta: Meta = {

--- a/docs/src/components/pane.stories.tsx
+++ b/docs/src/components/pane.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta } from "@storybook/react";
-import { Pane } from "../../../core/src";
+import { Pane } from "@moai/core";
 import { Utils } from "../utils/utils";
 
 const meta: Meta = {

--- a/docs/src/components/popover.stories.tsx
+++ b/docs/src/components/popover.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta } from "@storybook/react";
-import { Button, Popover, PopoverPlacement } from "../../../core/src";
+import { Button, Popover, PopoverPlacement } from "@moai/core";
 import { PLACEMENTS } from "../utils/placement";
 import { Utils } from "../utils/utils";
 

--- a/docs/src/components/progress-circle.stories.tsx
+++ b/docs/src/components/progress-circle.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/react";
-import { ProgressCircle, ProgressCircleProps } from "../../../core/src";
-import { GalleryProgress } from "../../../gallery/src/progress";
+import { ProgressCircle, ProgressCircleProps } from "@moai/core";
+import { GalleryProgress } from "@moai/gallery";
 import { Utils } from "../utils/utils";
 
 const meta: Meta = {

--- a/docs/src/components/radio-group-fake.tsx
+++ b/docs/src/components/radio-group-fake.tsx
@@ -1,4 +1,4 @@
-import { RadioOption } from "../../../core/src";
+import { RadioOption } from "@moai/core";
 
 /**
  * This is not a part of the source code. It exists only for Storybook's

--- a/docs/src/components/radio-group.stories.tsx
+++ b/docs/src/components/radio-group.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/react";
 import { useState } from "react";
-import { RadioGroup, RadioOption } from "../../../core/src";
+import { RadioGroup, RadioOption } from "@moai/core";
 import { Book, someBooks } from "../utils/example";
 import { Utils } from "../utils/utils";
 import { RadioOptionComponent } from "./radio-group-fake";

--- a/docs/src/components/radio.stories.tsx
+++ b/docs/src/components/radio.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/react";
 import { useState } from "react";
-import { Radio } from "../../../core/src";
+import { Radio } from "@moai/core";
 import { Book, someBooks } from "../utils/example";
 import { Utils } from "../utils/utils";
 

--- a/docs/src/components/select-fake.tsx
+++ b/docs/src/components/select-fake.tsx
@@ -1,4 +1,4 @@
-import { SelectOption } from "../../../core/src";
+import { SelectOption } from "@moai/core";
 
 /**
  * This is not a part of the source code. It exists only for Storybook's

--- a/docs/src/components/select.stories.tsx
+++ b/docs/src/components/select.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta } from "@storybook/react";
 import { useState } from "react";
-import { Select } from "../../../core/src";
-import { GallerySelect } from "../../../gallery/src/select";
+import { Select } from "@moai/core";
+import { GallerySelect } from "@moai/gallery";
 import { Utils } from "../utils/utils";
 import { SelectOptionComponent } from "./select-fake";
 

--- a/docs/src/components/step.stories.tsx
+++ b/docs/src/components/step.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta } from "@storybook/react";
-import { Steps } from "../../../core/src";
+import { Steps } from "@moai/core";
 
 export default {
 	title: "Draft/Steps",

--- a/docs/src/components/switcher-fake.tsx
+++ b/docs/src/components/switcher-fake.tsx
@@ -1,4 +1,4 @@
-import { SwitcherOption } from "../../../core/src";
+import { SwitcherOption } from "@moai/core";
 
 /**
  * This is not a part of the source code. It exists only for Storybook's

--- a/docs/src/components/switcher.stories.tsx
+++ b/docs/src/components/switcher.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta } from "@storybook/react/types-6-0";
 import { useState } from "react";
 import { FaAlignCenter, FaAlignLeft, FaAlignRight } from "react-icons/fa";
-import { Switcher, SwitcherOption } from "../../../core/src";
+import { Switcher, SwitcherOption } from "@moai/core";
 import { SwitcherOptionComponent } from "./switcher-fake";
 import { Utils } from "../utils/utils";
 

--- a/docs/src/components/tab-fake.tsx
+++ b/docs/src/components/tab-fake.tsx
@@ -1,4 +1,4 @@
-import { Tab } from "../../../core/src";
+import { Tab } from "@moai/core";
 
 /**
  * This is not a part of the source code. It exists only for Storybook's

--- a/docs/src/components/tab.stories.tsx
+++ b/docs/src/components/tab.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta } from "@storybook/react";
 import { useState } from "react";
-import { Button, DivPx, Switcher, Tab, Tabs } from "../../../core/src";
-import { GalleryTab1, GalleryTab2 } from "../../../gallery/src/tab";
+import { Button, DivPx, Switcher, Tab, Tabs } from "@moai/core";
+import { GalleryTab1, GalleryTab2 } from "@moai/gallery";
 import { Utils } from "../utils/utils";
 import { TabComponent } from "./tab-fake";
 

--- a/docs/src/components/table-fake.tsx
+++ b/docs/src/components/table-fake.tsx
@@ -1,5 +1,5 @@
-import { TableColumn } from "../../../core/src";
-import { TableExpandableProps } from "../../../core/src/table/expandable";
+import { TableColumn } from "@moai/core";
+import { TableExpandableProps } from "@moai/core";
 
 /**
  * This is not a part of the source code. It exists only for Storybook's

--- a/docs/src/components/table.stories.tsx
+++ b/docs/src/components/table.stories.tsx
@@ -1,8 +1,8 @@
 import { Meta } from "@storybook/react";
 import { useState } from "react";
-import { Pane, Table, TableColumn } from "../../../core/src";
-import { Robot, ROBOTS } from "../../../gallery/src/table/robots";
-import { GalleryTable } from "../../../gallery/src/table/table";
+import { Pane, Table, TableColumn } from "@moai/core";
+import { Robot, ROBOTS } from "@moai/gallery";
+import { GalleryTable } from "@moai/gallery";
 import { Book, someBooks } from "../utils/example";
 import { Utils } from "../utils/utils";
 import { TableColumnComponent, TableExpandableComponent } from "./table-fake";

--- a/docs/src/components/tag.stories.tsx
+++ b/docs/src/components/tag.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta } from "@storybook/react";
-import { Tag } from "../../../core/src";
+import { Tag } from "@moai/core";
 import { Utils } from "../utils/utils";
-import { GalleryTag } from "../../../gallery/src/tag";
+import { GalleryTag } from "@moai/gallery";
 
 const meta: Meta = {
 	title: "Components/Tag",

--- a/docs/src/components/text-area.stories.tsx
+++ b/docs/src/components/text-area.stories.tsx
@@ -1,4 +1,4 @@
-import { TextArea } from "../../../core/src";
+import { TextArea } from "@moai/core";
 import { Utils } from "../utils/utils";
 
 export default {

--- a/docs/src/components/time-input.stories.tsx
+++ b/docs/src/components/time-input.stories.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { TimeInput } from "../../../core/src";
+import { TimeInput } from "@moai/core";
 import { Utils } from "../utils/utils";
 
 const meta = {

--- a/docs/src/components/toast-fake.tsx
+++ b/docs/src/components/toast-fake.tsx
@@ -1,4 +1,4 @@
-import { ToastType } from "../../../core/src";
+import { ToastType } from "@moai/core";
 
 interface Props {
 	/**

--- a/docs/src/components/toast.stories.tsx
+++ b/docs/src/components/toast.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta } from "@storybook/react";
 import { useState } from "react";
-import { Button, toast, ToastPane } from "../../../core/src";
-import { GalleryToast } from "../../../gallery/src/toast";
+import { Button, toast, ToastPane } from "@moai/core";
+import { GalleryToast } from "@moai/gallery";
 import { Utils } from "../utils/utils";
 import { ToastFunction } from "./toast-fake";
 

--- a/docs/src/components/tooltip.stories.tsx
+++ b/docs/src/components/tooltip.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta } from "@storybook/react";
-import { Tooltip, TooltipProps } from "../../../core/src";
+import { Tooltip, TooltipProps } from "@moai/core";
 import { PLACEMENTS } from "../utils/placement";
 import { Utils } from "../utils/utils";
 

--- a/docs/src/guides/gallery.stories.mdx
+++ b/docs/src/guides/gallery.stories.mdx
@@ -1,5 +1,5 @@
 import { Meta } from "@storybook/addon-docs";
-import { Gallery } from "../../../gallery/src";
+import { Gallery } from "@moai/gallery";
 
 <Meta title="Intro/Gallery" />
 

--- a/docs/src/patterns/form.stories.tsx
+++ b/docs/src/patterns/form.stories.tsx
@@ -2,7 +2,7 @@ import { Meta } from "@storybook/react/types-6-0";
 import { ErrorMessage, Field, Form, Formik, FormikErrors } from "formik";
 import { CSSProperties, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
-import { Button, FormError, Input, TextArea } from "../../../core/src";
+import { Button, FormError, Input, TextArea } from "@moai/core";
 import { Utils } from "../utils/utils";
 
 const meta: Meta = {

--- a/docs/src/patterns/icon.stories.tsx
+++ b/docs/src/patterns/icon.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta } from "@storybook/react/types-6-0";
 import { SVGAttributes } from "react";
 import { RiSearchLine } from "react-icons/ri";
-import { Button } from "../../../core/src";
+import { Button } from "@moai/core";
 import { Utils } from "../utils/utils";
 
 const meta: Meta = {

--- a/docs/src/utils/page/component.tsx
+++ b/docs/src/utils/page/component.tsx
@@ -8,7 +8,7 @@ import {
 } from "@storybook/addon-docs";
 import { Meta } from "@storybook/react";
 import React from "react";
-import { background } from "../../../../core/src";
+import { background } from "@moai/core";
 import s from "./component.module.css";
 
 interface Props {

--- a/docs/src/utils/placement.ts
+++ b/docs/src/utils/placement.ts
@@ -1,4 +1,4 @@
-import { PopoverPlacement } from "../../../core/src";
+import { PopoverPlacement } from "@moai/core";
 
 export const PLACEMENTS: PopoverPlacement[] = [
 	"top",

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,5 +1,5 @@
 {
 	"extends": "../tsconfig.json",
-	"references": [{ "path": "../core" }],
+	"references": [{ "path": "../core" }, { "path": "../gallery" }],
 	"include": ["src/**/*"]
 }

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -4,7 +4,7 @@
 	"description": "Widget Gallery of Moai 🗿",
 	"main": "dist/cjs.js",
 	"module": "dist/esm.js",
-	"types": "dist/gallery/src/index.d.ts",
+	"types": "dist/types/index.d.ts",
 	"sideEffects": false,
 	"files": [
 		"dist"
@@ -12,6 +12,7 @@
 	"scripts": {
 		"example": "ts-node ./scripts/example/generate.ts",
 		"build": "rollup --config",
+		"start": "rollup --config --watch",
 		"prepublishOnly": "yarn build"
 	},
 	"repository": {
@@ -24,14 +25,14 @@
 	},
 	"homepage": "https://moaijs.com",
 	"email": "hi@moaijs.com",
+	"dependencies": {
+		"@moai/core": "*"
+	},
 	"peerDependencies": {
-		"@moai/core": ">=0",
 		"react": ">=16",
 		"react-icons": ">=4"
 	},
 	"devDependencies": {
-		"@moai/core": "^1.0.0-rc9",
-		"@rollup/plugin-alias": "^3.1.2",
 		"@types/react": "^17.0.11",
 		"node-fetch": "^2.6.1",
 		"postcss": "^8.3.5",

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -12,7 +12,7 @@
 	"scripts": {
 		"example": "ts-node ./scripts/example/generate.ts",
 		"build": "rollup --config",
-		"start": "rollup --config --watch",
+		"watch": "rollup --config --watch",
 		"prepublishOnly": "yarn build"
 	},
 	"repository": {

--- a/gallery/rollup.config.js
+++ b/gallery/rollup.config.js
@@ -1,6 +1,5 @@
 /* eslint-env node */
 
-import alias from "@rollup/plugin-alias";
 import del from "rollup-plugin-delete";
 import postcss from "rollup-plugin-postcss";
 import typescript2 from "rollup-plugin-typescript2";
@@ -40,14 +39,6 @@ const config = {
 	plugins: [
 		del({
 			targets: ["dist"],
-		}),
-		// This is the "magic" bit. It means:
-		// - In local dev, "gallery" always use the src of "core", so e.g. in
-		//   storybook you always see the latest change of core inside gallery
-		// - However, when bundling, "gallery" will reference to "@moai/core",
-		//   the npm package inside the end user's node_modules!
-		alias({
-			entries: [{ find: /.*..\/core\/src/, replacement: "@moai/core" }],
 		}),
 		postcss({
 			minimize: false,

--- a/gallery/src/button-1.tsx
+++ b/gallery/src/button-1.tsx
@@ -1,4 +1,4 @@
-import { Button, ButtonProps } from "../../core/src";
+import { Button, ButtonProps } from "@moai/core";
 import { Shot } from "./shot/shot";
 import s from "./styles.module.css";
 

--- a/gallery/src/button-2.tsx
+++ b/gallery/src/button-2.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import * as Go from "react-icons/go";
-import { Button, ButtonProps } from "../../core/src";
+import { Button, ButtonProps } from "@moai/core";
 import { Shot } from "./shot/shot";
 import s from "./styles.module.css";
 

--- a/gallery/src/checkbox.tsx
+++ b/gallery/src/checkbox.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, CheckboxProps, Radio, RadioProps } from "../../core/src";
+import { Checkbox, CheckboxProps, Radio, RadioProps } from "@moai/core";
 import { Shot } from "./shot/shot";
 import s from "./styles.module.css";
 

--- a/gallery/src/dialog.tsx
+++ b/gallery/src/dialog.tsx
@@ -1,4 +1,4 @@
-import * as M from "../../core/src";
+import * as M from "@moai/core";
 import { Shot } from "./shot/shot";
 import s from "./styles.module.css";
 

--- a/gallery/src/gallery.tsx
+++ b/gallery/src/gallery.tsx
@@ -1,0 +1,67 @@
+import { scrollbar } from "@moai/core";
+import { GalleryButton1 } from "./button-1";
+import { GalleryButton2 } from "./button-2";
+import { GalleryCheckbox } from "./checkbox";
+import { GalleryDialog } from "./dialog";
+import { GalleryIcon } from "./icon/icon";
+import { GalleryInput1 } from "./input-1";
+import { GalleryInput2 } from "./input-2";
+import { GallerPagination } from "./pagination";
+import { GalleryContainerPane } from "./pane";
+import { GalleryProgress } from "./progress";
+import { GallerySection } from "./section/section";
+import { GallerySelect } from "./select";
+import s from "./styles.module.css";
+import { GalleryTab1, GalleryTab2 } from "./tab";
+import { GalleryTable } from "./table/table";
+import { GalleryTag } from "./tag";
+import { GalleryToast } from "./toast";
+import { GalleryTooltip } from "./tooltip";
+
+export const Gallery = (): JSX.Element => (
+	<div className={[scrollbar.custom, s.rows].join(" ")} style={{ gap: 32 }}>
+		<GallerySection title="Icons">
+			<div className={s.colFull}>
+				<GalleryIcon />
+			</div>
+		</GallerySection>
+		<GallerySection title="Buttons">
+			<GalleryButton1 />
+			<GalleryButton2 />
+		</GallerySection>
+		<GallerySection title="Text fields">
+			<GalleryInput1 />
+			<GalleryInput2 />
+		</GallerySection>
+		<GallerySection title="Selection controls">
+			<div className={s.rows}>
+				<GallerySelect />
+				<GallerPagination />
+			</div>
+			<GalleryCheckbox />
+		</GallerySection>
+		<GallerySection title="Feedback">
+			<div className={s.rows} style={{ gap: 16 }}>
+				<GalleryToast />
+				<GalleryTag />
+			</div>
+			<div className={s.rows} style={{ gap: 16 }}>
+				<GalleryTooltip />
+				<GalleryProgress />
+			</div>
+		</GallerySection>
+		<GallerySection title="Container">
+			<GalleryDialog />
+			<GalleryContainerPane />
+		</GallerySection>
+		<GallerySection title="Tabs">
+			<GalleryTab1 />
+			<GalleryTab2 />
+		</GallerySection>
+		<GallerySection title="Table">
+			<div className={s.colFull}>
+				<GalleryTable />
+			</div>
+		</GallerySection>
+	</div>
+);

--- a/gallery/src/icon/icon.tsx
+++ b/gallery/src/icon/icon.tsx
@@ -1,4 +1,4 @@
-import { Icon, IconComponent } from "../../../core/src";
+import { Icon, IconComponent } from "@moai/core";
 import { AiOutlineHome } from "react-icons/ai";
 import { BiHome } from "react-icons/bi";
 import { FiHome } from "react-icons/fi";

--- a/gallery/src/index.tsx
+++ b/gallery/src/index.tsx
@@ -1,69 +1,20 @@
-import { scrollbar } from "../../core/src";
-import { GalleryButton1 } from "./button-1";
-import { GalleryButton2 } from "./button-2";
-import { GalleryContainerPane } from "./container/pane";
-import { GalleryDialog } from "./dialog";
-import { GalleryProgress } from "./progress";
-import { GalleryTag } from "./tag";
-import { GalleryToast } from "./toast";
-import { GalleryTooltip } from "./tooltip";
-import { GalleryInput1 } from "./input-1";
-import { GalleryInput2 } from "./input-2";
-import { GallerySection } from "./section/section";
-import { GalleryCheckbox } from "./checkbox";
-import { GallerPagination } from "./selection/pagination";
-import { GallerySelect } from "./select";
-import s from "./styles.module.css";
-import { GalleryTab1, GalleryTab2 } from "./tab";
-import { GalleryTable } from "./table/table";
-import { GalleryIcon } from "./icon/icon";
-
-export { GallerySection };
-
-export const Gallery = (): JSX.Element => (
-	<div className={[scrollbar.custom, s.rows].join(" ")} style={{ gap: 32 }}>
-		<GallerySection title="Icons">
-			<div className={s.colFull}>
-				<GalleryIcon />
-			</div>
-		</GallerySection>
-		<GallerySection title="Buttons">
-			<GalleryButton1 />
-			<GalleryButton2 />
-		</GallerySection>
-		<GallerySection title="Text fields">
-			<GalleryInput1 />
-			<GalleryInput2 />
-		</GallerySection>
-		<GallerySection title="Selection controls">
-			<div className={s.rows}>
-				<GallerySelect />
-				<GallerPagination />
-			</div>
-			<GalleryCheckbox />
-		</GallerySection>
-		<GallerySection title="Feedback">
-			<div className={s.rows} style={{ gap: 16 }}>
-				<GalleryToast />
-				<GalleryTag />
-			</div>
-			<div className={s.rows} style={{ gap: 16 }}>
-				<GalleryTooltip />
-				<GalleryProgress />
-			</div>
-		</GallerySection>
-		<GallerySection title="Container">
-			<GalleryDialog />
-			<GalleryContainerPane />
-		</GallerySection>
-		<GallerySection title="Tabs">
-			<GalleryTab1 />
-			<GalleryTab2 />
-		</GallerySection>
-		<GallerySection title="Table">
-			<div className={s.colFull}>
-				<GalleryTable />
-			</div>
-		</GallerySection>
-	</div>
-);
+export { GalleryButton1 } from "./button-1";
+export { GalleryButton2 } from "./button-2";
+export { GalleryCheckbox } from "./checkbox";
+export { GalleryDialog } from "./dialog";
+export { Gallery } from "./gallery";
+export { GalleryIcon } from "./icon/icon";
+export { GalleryInput1 } from "./input-1";
+export { GalleryInput2 } from "./input-2";
+export { GallerPagination } from "./pagination";
+export { GalleryContainerPane } from "./pane";
+export { GalleryProgress } from "./progress";
+export { GallerySection } from "./section/section";
+export { GallerySelect } from "./select";
+export { GalleryTab1, GalleryTab2 } from "./tab";
+export { GalleryTable } from "./table/table";
+export type { Robot } from "./table/robots";
+export { ROBOTS } from "./table/robots";
+export { GalleryTag } from "./tag";
+export { GalleryToast } from "./toast";
+export { GalleryTooltip } from "./tooltip";

--- a/gallery/src/input-1.tsx
+++ b/gallery/src/input-1.tsx
@@ -1,4 +1,4 @@
-import { Input, InputStyle } from "../../core/src";
+import { Input, InputStyle } from "@moai/core";
 import { Shot } from "./shot/shot";
 import s from "./styles.module.css";
 

--- a/gallery/src/input-2.tsx
+++ b/gallery/src/input-2.tsx
@@ -1,6 +1,6 @@
 import { ButtonGroupItemProps } from "@moai/core";
 import { GoSearch } from "react-icons/go";
-import { Button, ButtonGroup, Input } from "../../core/src";
+import { Button, ButtonGroup, Input } from "@moai/core";
 import { Shot } from "./shot/shot";
 import s from "./styles.module.css";
 import { MATERIALS } from "./table/robots";

--- a/gallery/src/pagination.tsx
+++ b/gallery/src/pagination.tsx
@@ -1,4 +1,4 @@
-import { Pagination } from "../../../core/src";
+import { Pagination } from "@moai/core";
 import { useCallback, useState } from "react";
 
 export const GallerPagination = (): JSX.Element => {

--- a/gallery/src/pane.tsx
+++ b/gallery/src/pane.tsx
@@ -1,5 +1,5 @@
-import * as M from "../../../core/src";
-import s from "../styles.module.css";
+import * as M from "@moai/core";
+import s from "./styles.module.css";
 
 const items: M.MenuItemProps[] = [
 	{ label: "Menu item 1" },

--- a/gallery/src/progress.tsx
+++ b/gallery/src/progress.tsx
@@ -1,4 +1,4 @@
-import { ProgressCircle } from "../../core/src";
+import { ProgressCircle } from "@moai/core";
 import { Shot } from "./shot/shot";
 import s from "./styles.module.css";
 

--- a/gallery/src/section/section.tsx
+++ b/gallery/src/section/section.tsx
@@ -1,4 +1,4 @@
-import { DivPx } from "../../../core/src";
+import { DivPx } from "@moai/core";
 import s from "./section.module.css";
 
 interface Props {

--- a/gallery/src/select.tsx
+++ b/gallery/src/select.tsx
@@ -1,4 +1,4 @@
-import * as M from "../../core/src";
+import * as M from "@moai/core";
 import s from "./styles.module.css";
 import { MATERIALS } from "./table/robots";
 import { GoSearch } from "react-icons/go";

--- a/gallery/src/tab.tsx
+++ b/gallery/src/tab.tsx
@@ -1,4 +1,4 @@
-import { Paragraph, Tab, Tabs } from "../../core/src";
+import { Paragraph, Tab, Tabs } from "@moai/core";
 import { Shot } from "./shot/shot";
 
 const Second = () => (

--- a/gallery/src/table/table.tsx
+++ b/gallery/src/table/table.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useState } from "react";
-import * as M from "../../../core/src";
+import * as M from "@moai/core";
 import { Robot, ROBOTS } from "./robots";
 import s from "./table.module.css";
 import { GoSearch, GoMail } from "react-icons/go";

--- a/gallery/src/tag.tsx
+++ b/gallery/src/tag.tsx
@@ -1,4 +1,4 @@
-import { Tag } from "../../core/src";
+import { Tag } from "@moai/core";
 import s from "./styles.module.css";
 
 const getColor = (color: string): string => {

--- a/gallery/src/toast.tsx
+++ b/gallery/src/toast.tsx
@@ -1,4 +1,4 @@
-import { Button, Dialog, toast, ToastPane } from "../../core/src";
+import { Button, Dialog, toast, ToastPane } from "@moai/core";
 import { Shot } from "./shot/shot";
 import s from "./styles.module.css";
 

--- a/gallery/src/tooltip.tsx
+++ b/gallery/src/tooltip.tsx
@@ -1,4 +1,4 @@
-import { DivPx, Button, Tooltip, TooltipPane } from "../../core/src";
+import { DivPx, Button, Tooltip, TooltipPane } from "@moai/core";
 import { Shot } from "./shot/shot";
 
 export const GalleryTooltip = (): JSX.Element => (

--- a/gallery/tsconfig.json
+++ b/gallery/tsconfig.json
@@ -1,8 +1,10 @@
 {
 	"extends": "../tsconfig.json",
 	"compilerOptions": {
+		"composite": true,
 		"declaration": true,
-		"declarationDir": "dist"
+		"declarationDir": "dist/types",
+		"rootDir": "src"
 	},
 	"references": [{ "path": "../core" }],
 	"include": ["src/**/*"]

--- a/package.json
+++ b/package.json
@@ -9,15 +9,17 @@
 		"test"
 	],
 	"scripts": {
-		"build-core": "cd core && yarn build",
-		"build-docs": "cd docs && yarn build",
-		"build-gallery": "cd core && yarn build",
+		"build:docs": "cd docs && yarn build",
+		"build:npm:core": "cd core && yarn build",
+		"build:npm:gallery": "cd gallery && yarn build",
+		"build:npm": "run-p build:npm:* -l",
+		"build": "run-s build:npm build:docs",
 		"lint-fix": "eslint --fix . && prettier --write .",
 		"lint": "eslint --max-warnings=0 . && prettier --check .",
-		"start-core": "cd core && yarn start",
-		"start-docs": "cd docs && yarn start",
-		"start-gallery": "cd gallery && yarn start",
-		"test": "cd test && yarn test"
+		"start:docs": "cd docs && yarn start",
+		"test": "cd test && yarn test",
+		"watch:core": "cd core && yarn watch",
+		"watch:gallery": "cd gallery && yarn watch"
 	},
 	"devDependencies": {
 		"@typescript-eslint/eslint-plugin": "^4.28.1",
@@ -27,5 +29,8 @@
 		"eslint-plugin-react": "^7.24.0",
 		"prettier": "^2.3.2",
 		"typescript": "^4.3.5"
+	},
+	"dependencies": {
+		"npm-run-all": "^4.1.5"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -9,10 +9,14 @@
 		"test"
 	],
 	"scripts": {
-		"lint": "eslint --max-warnings=0 . && prettier --check .",
+		"build-core": "cd core && yarn build",
+		"build-docs": "cd docs && yarn build",
+		"build-gallery": "cd core && yarn build",
 		"lint-fix": "eslint --fix . && prettier --write .",
-		"core": "cd core && yarn start",
-		"docs": "cd docs && yarn start",
+		"lint": "eslint --max-warnings=0 . && prettier --check .",
+		"start-core": "cd core && yarn start",
+		"start-docs": "cd docs && yarn start",
+		"start-gallery": "cd gallery && yarn start",
 		"test": "cd test && yarn test"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,17 +9,16 @@
 		"test"
 	],
 	"scripts": {
-		"build:docs": "cd docs && yarn build",
-		"build:npm:core": "cd core && yarn build",
-		"build:npm:gallery": "cd gallery && yarn build",
-		"build:npm": "run-p build:npm:* -l",
-		"build": "run-s build:npm build:docs",
+		"build-core": "cd core && yarn build",
+		"build-docs": "cd docs && yarn build",
+		"build-gallery": "cd gallery && yarn build",
+		"build": "yarn build-core && yarn build-gallery && yarn build-docs",
 		"lint-fix": "eslint --fix . && prettier --write .",
 		"lint": "eslint --max-warnings=0 . && prettier --check .",
-		"start:docs": "cd docs && yarn start",
-		"test": "cd test && yarn test",
-		"watch:core": "cd core && yarn watch",
-		"watch:gallery": "cd gallery && yarn watch"
+		"start-core": "cd core && yarn watch",
+		"start-docs": "cd docs && yarn start",
+		"start-gallery": "cd gallery && yarn watch",
+		"test": "cd test && yarn test"
 	},
 	"devDependencies": {
 		"@typescript-eslint/eslint-plugin": "^4.28.1",
@@ -29,8 +28,5 @@
 		"eslint-plugin-react": "^7.24.0",
 		"prettier": "^2.3.2",
 		"typescript": "^4.3.5"
-	},
-	"dependencies": {
-		"npm-run-all": "^4.1.5"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1583,13 +1583,6 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
 
-"@rollup/plugin-alias@^3.1.2":
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-alias/-/plugin-alias-3.1.2.tgz#c585b05be4a7782d269c69d13def56f44e417772"
-  integrity sha512-wzDnQ6v7CcoRzS0qVwFPrFdYA4Qlr+ookA217Y2Z3DPZE1R8jrFNM3jvGgOf6o6DMjbnQIn5lCIJgHPe1Bt3uw==
-  dependencies:
-    slash "^3.0.0"
-
 "@rollup/pluginutils@^4.1.0":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-4.1.0.tgz#0dcc61c780e39257554feb7f77207dceca13c838"
@@ -1673,7 +1666,7 @@
     postcss-loader "^4.2.0"
     style-loader "^1.3.0"
 
-"@storybook/addons@6.3.2", "@storybook/addons@^6.3.2":
+"@storybook/addons@6.3.2":
   version "6.3.2"
   resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-6.3.2.tgz#a116f71e07e2ca17f2c59accff8aebd0d01e3a3e"
   integrity sha512-fzpTLKyweD0yPXnfjaOrLpKRm4AVHdGRmfJb1p6KyUTXoNRWGYHsXN3EvAdsWjTamhbL2JoQy38kvu7SmkTEug==
@@ -1688,7 +1681,7 @@
     global "^4.4.0"
     regenerator-runtime "^0.13.7"
 
-"@storybook/api@6.3.2", "@storybook/api@^6.3.2":
+"@storybook/api@6.3.2":
   version "6.3.2"
   resolved "https://registry.yarnpkg.com/@storybook/api/-/api-6.3.2.tgz#669c9eb1b5f50659b894f374af1c3eb3d4c2ac20"
   integrity sha512-rXe7l8mwNEvk3cqHYJ4H2XQWWY8oeezJezgt1ZBq4GvNVzVUPjASi1meXQwAYm39SdCL5+lP/hLpAZvobB1Tag==
@@ -1844,7 +1837,7 @@
     core-js "^3.8.2"
     global "^4.4.0"
 
-"@storybook/components@6.3.2", "@storybook/components@^6.3.2":
+"@storybook/components@6.3.2":
   version "6.3.2"
   resolved "https://registry.yarnpkg.com/@storybook/components/-/components-6.3.2.tgz#fa8970fdfe76246a020f757a7059f312ae2420ce"
   integrity sha512-lwzqY7CLbo+4PxBiN9DMwtMRPG1jN9Ih6SAdB4fJdCj3bZQ7ef9peme70RvpDEIOD3MX6vu/9AKQj2wxAaHrDA==
@@ -1951,7 +1944,7 @@
     util-deprecate "^1.0.2"
     webpack "4"
 
-"@storybook/core-events@6.3.2", "@storybook/core-events@^6.3.2":
+"@storybook/core-events@6.3.2":
   version "6.3.2"
   resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-6.3.2.tgz#7d1eb4f889b809d851e48d2daed5fbf43244d624"
   integrity sha512-Mqxp2au4djPC9j8Wc97oM1iJQLAS8ZsW8CqcPxDmhl38cMfcMQiQXTk+2GDQbMxD2An2b73EU5hMMBAvNzYjog==
@@ -4590,7 +4583,7 @@ cross-spawn@7.0.3, cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cross-spawn@^6.0.0:
+cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
   integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
@@ -8071,6 +8064,16 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
+load-json-file@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b"
+  integrity sha1-L19Fq5HjMhYjT9U62rZo607AmTs=
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^4.0.0"
+    pify "^3.0.0"
+    strip-bom "^3.0.0"
+
 loader-runner@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
@@ -8360,6 +8363,11 @@ memory-fs@^0.5.0:
   dependencies:
     errno "^0.1.3"
     readable-stream "^2.0.1"
+
+memorystream@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
+  integrity sha1-htcJCzDORV1j+64S3aUaR93K+bI=
 
 merge-descriptors@1.0.1:
   version "1.0.1"
@@ -8714,7 +8722,7 @@ node-releases@^1.1.61, node-releases@^1.1.71:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.73.tgz#dd4e81ddd5277ff846b80b52bb40c49edf7a7b20"
   integrity sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==
 
-normalize-package-data@^2.5.0:
+normalize-package-data@^2.3.2, normalize-package-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
   integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
@@ -8745,6 +8753,21 @@ normalize-url@^3.0.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
   integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
+
+npm-run-all@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/npm-run-all/-/npm-run-all-4.1.5.tgz#04476202a15ee0e2e214080861bff12a51d98fba"
+  integrity sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    chalk "^2.4.1"
+    cross-spawn "^6.0.5"
+    memorystream "^0.3.1"
+    minimatch "^3.0.4"
+    pidtree "^0.3.0"
+    read-pkg "^3.0.0"
+    shell-quote "^1.6.1"
+    string.prototype.padend "^3.0.0"
 
 npm-run-path@^2.0.0:
   version "2.0.2"
@@ -9227,6 +9250,11 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.2, picomatch@^2.2.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
   integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
+
+pidtree@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.3.1.tgz#ef09ac2cc0533df1f3250ccf2c4d366b0d12114a"
+  integrity sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==
 
 pify@^2.3.0:
   version "2.3.0"
@@ -10212,6 +10240,15 @@ read-pkg-up@^7.0.1:
     read-pkg "^5.2.0"
     type-fest "^0.8.1"
 
+read-pkg@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-3.0.0.tgz#9cbc686978fee65d16c00e2b19c237fcf6e38389"
+  integrity sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=
+  dependencies:
+    load-json-file "^4.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^3.0.0"
+
 read-pkg@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-5.2.0.tgz#7bf295438ca5a33e56cd30e053b34ee7250c93cc"
@@ -10875,7 +10912,7 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shell-quote@1.7.2:
+shell-quote@1.7.2, shell-quote@^1.6.1:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
   integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
@@ -11278,6 +11315,11 @@ strip-ansi@^5.1.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+  integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
 
 strip-bom@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4583,7 +4583,7 @@ cross-spawn@7.0.3, cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cross-spawn@^6.0.0, cross-spawn@^6.0.5:
+cross-spawn@^6.0.0:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
   integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
@@ -8064,16 +8064,6 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-load-json-file@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b"
-  integrity sha1-L19Fq5HjMhYjT9U62rZo607AmTs=
-  dependencies:
-    graceful-fs "^4.1.2"
-    parse-json "^4.0.0"
-    pify "^3.0.0"
-    strip-bom "^3.0.0"
-
 loader-runner@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
@@ -8363,11 +8353,6 @@ memory-fs@^0.5.0:
   dependencies:
     errno "^0.1.3"
     readable-stream "^2.0.1"
-
-memorystream@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
-  integrity sha1-htcJCzDORV1j+64S3aUaR93K+bI=
 
 merge-descriptors@1.0.1:
   version "1.0.1"
@@ -8722,7 +8707,7 @@ node-releases@^1.1.61, node-releases@^1.1.71:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.73.tgz#dd4e81ddd5277ff846b80b52bb40c49edf7a7b20"
   integrity sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==
 
-normalize-package-data@^2.3.2, normalize-package-data@^2.5.0:
+normalize-package-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
   integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
@@ -8753,21 +8738,6 @@ normalize-url@^3.0.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
   integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
-
-npm-run-all@^4.1.5:
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/npm-run-all/-/npm-run-all-4.1.5.tgz#04476202a15ee0e2e214080861bff12a51d98fba"
-  integrity sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==
-  dependencies:
-    ansi-styles "^3.2.1"
-    chalk "^2.4.1"
-    cross-spawn "^6.0.5"
-    memorystream "^0.3.1"
-    minimatch "^3.0.4"
-    pidtree "^0.3.0"
-    read-pkg "^3.0.0"
-    shell-quote "^1.6.1"
-    string.prototype.padend "^3.0.0"
 
 npm-run-path@^2.0.0:
   version "2.0.2"
@@ -9250,11 +9220,6 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.2, picomatch@^2.2.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
   integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
-
-pidtree@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.3.1.tgz#ef09ac2cc0533df1f3250ccf2c4d366b0d12114a"
-  integrity sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==
 
 pify@^2.3.0:
   version "2.3.0"
@@ -10240,15 +10205,6 @@ read-pkg-up@^7.0.1:
     read-pkg "^5.2.0"
     type-fest "^0.8.1"
 
-read-pkg@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-3.0.0.tgz#9cbc686978fee65d16c00e2b19c237fcf6e38389"
-  integrity sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=
-  dependencies:
-    load-json-file "^4.0.0"
-    normalize-package-data "^2.3.2"
-    path-type "^3.0.0"
-
 read-pkg@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-5.2.0.tgz#7bf295438ca5a33e56cd30e053b34ee7250c93cc"
@@ -10912,7 +10868,7 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shell-quote@1.7.2, shell-quote@^1.6.1:
+shell-quote@1.7.2:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
   integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
@@ -11315,11 +11271,6 @@ strip-ansi@^5.1.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-bom@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
-  integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
 
 strip-bom@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Previously, the "docs" project import files from "core" and "gallery" directly (i.e. "../../../core"). This let us run only 1 process to watch for changes in all projects. However, this is quite wrong:

- We don't actually use the distribution build, so things may be different between development and distribution.
- The Storybook must be set up to process our source files in core and gallery. This is a big workaround that still work but is very dangerous to leave it there.

After this PR, to work on Moai you'd usually need 2 terminal windows, one for the "docs" and one for the "core". We may use "npm-run-all" to combine them later. However, this is the better way.

As a side note, the "test" project already uses this approach.