### PR TITLE
Docs: Fix missing TSDoc

### DIFF
--- a/docs/.storybook/manager.js
+++ b/docs/.storybook/manager.js
@@ -1,7 +1,7 @@
 import { addons } from "@storybook/addons";
 // Use the remote font since the manager is not set up to import local fonts
 // (i.e. woff2 files)
-import "@moai/core/dist/font/remote.css";
+import "../../core/font/remote.css";
 
 addons.setConfig({
 	initialActive: "addons",

--- a/docs/.storybook/preview.js
+++ b/docs/.storybook/preview.js
@@ -1,8 +1,10 @@
 import * as D from "@storybook/addon-docs/blocks";
 import { useDarkMode } from "storybook-dark-mode";
+import "../../core/font/remote.css";
+import "../../core/src/global/global.css";
+// This is kind of a temporary workaround.. it's necessary because @moai/gallery
+// does not use the src of core like the docs, but instead use the dist build
 import "@moai/core/dist/bundle.css";
-import "@moai/core/dist/font/remote.css";
-import "@moai/gallery/dist/bundle.css";
 import "./preview.css";
 import "./syntax.css";
 import { darkTheme, lightTheme } from "./theme";

--- a/docs/package.json
+++ b/docs/package.json
@@ -21,8 +21,6 @@
 		"@storybook/react": "^6.3.1",
 		"@storybook/theming": "^6.3.1",
 		"@types/color": "^3.0.1",
-		"@moai/core": "*",
-		"@moai/gallery": "*",
 		"autoprefixer": "^10.2.6",
 		"color": "^3.1.3",
 		"formik": "^2.2.9",

--- a/docs/src/color/background/background.stories.mdx
+++ b/docs/src/color/background/background.stories.mdx
@@ -10,7 +10,7 @@ The `background` utility contains classes that set the
 background color since they automatically change based on the current theme.
 
 ```ts
-import { background } from "@moai/core";
+import { background } from "../../../../core/src";
 
 <div className={background.weak}>Text</div>;
 ```

--- a/docs/src/color/background/background.tsx
+++ b/docs/src/color/background/background.tsx
@@ -1,4 +1,4 @@
-import { border, background, Table, text } from "@moai/core";
+import { border, background, Table, text } from "../../../../core/src";
 import { ColorSample } from "../sample/sample";
 import s from "./background.module.css";
 

--- a/docs/src/color/border/border.stories.mdx
+++ b/docs/src/color/border/border.stories.mdx
@@ -14,7 +14,7 @@ width, e.g. using the "border" class from Tailwind. You don't need to set the
 border style since it's already default to "solid" in our [CSS reset][2].
 
 ```ts
-import { border } from "@moai/core";
+import { border } from "../../../../core/src";
 
 // The "border" class comes from Tailwind to set the border width
 <div className={[border.weak, "border"].join(" ")}>Text</div>;

--- a/docs/src/color/border/border.tsx
+++ b/docs/src/color/border/border.tsx
@@ -1,4 +1,4 @@
-import { background, border, Table } from "@moai/core";
+import { background, border, Table } from "../../../../core/src";
 import { ColorSample } from "../sample/sample";
 import s from "./border.module.css";
 

--- a/docs/src/color/category/category.tsx
+++ b/docs/src/color/category/category.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { border, Table } from "@moai/core";
-import { GalleryTag } from "@moai/gallery";
+import { border, Table } from "../../../../core/src";
+import { GalleryTag } from "../../../../gallery/src";
 import s from "./category.module.css";
 
 interface Row {

--- a/docs/src/color/sample/sample.tsx
+++ b/docs/src/color/sample/sample.tsx
@@ -1,7 +1,7 @@
 import Color from "color";
 import { useEffect, useRef, useState } from "react";
 import { HiCheckCircle } from "react-icons/hi";
-import { CategoryColor, categoryColors, Icon, Tag } from "@moai/core";
+import { CategoryColor, categoryColors, Icon, Tag } from "../../../../core/src";
 import s from "./sample.module.css";
 
 export type ColorSampleUsage = "text" | "icon" | "both";

--- a/docs/src/color/static/sample.tsx
+++ b/docs/src/color/static/sample.tsx
@@ -1,6 +1,6 @@
 import Color from "color";
 import { useEffect, useRef, useState } from "react";
-import { text } from "@moai/core";
+import { text } from "../../../../core/src";
 import s from "./sample.module.css";
 
 interface Props {

--- a/docs/src/color/static/table.tsx
+++ b/docs/src/color/static/table.tsx
@@ -1,4 +1,4 @@
-import { border, Table } from "@moai/core";
+import { border, Table } from "../../../../core/src";
 import { ColorStaticSample } from "./sample";
 import s from "./table.module.css";
 

--- a/docs/src/color/text/text.stories.mdx
+++ b/docs/src/color/text/text.stories.mdx
@@ -11,7 +11,7 @@ automatically change based on the current theme and always conform to the
 [WCAG of contrast ratios][3] at AA level.
 
 ```ts
-import { text } from "@moai/core";
+import { text } from "../../../../core/src";
 
 <span className={text.muted}>Text</span>;
 ```

--- a/docs/src/color/text/text.tsx
+++ b/docs/src/color/text/text.tsx
@@ -1,4 +1,4 @@
-import { background, border, Table, text } from "@moai/core";
+import { background, border, Table, text } from "../../../../core/src";
 import { ColorSample, ColorSampleUsage } from "../sample/sample";
 import s from "./text.module.css";
 

--- a/docs/src/components/button-group.stories.tsx
+++ b/docs/src/components/button-group.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/react";
 import { GoSearch } from "react-icons/go";
-import { Button, ButtonGroup, Input, Select } from "@moai/core";
+import { Button, ButtonGroup, Input, Select } from "../../../core/src";
 
 export default {
 	title: "Draft/Button Group",

--- a/docs/src/components/button.stories.tsx
+++ b/docs/src/components/button.stories.tsx
@@ -1,8 +1,8 @@
 import { Meta } from "@storybook/react";
 import { GoPlus } from "react-icons/go";
-import { Button, Dialog } from "@moai/core";
-import { GalleryButton1 } from "@moai/gallery";
-import { GalleryButton2 } from "@moai/gallery";
+import { Button, Dialog } from "../../../core/src";
+import { GalleryButton1 } from "../../../gallery/src";
+import { GalleryButton2 } from "../../../gallery/src";
 import { Utils } from "../utils/utils";
 
 const meta: Meta = {

--- a/docs/src/components/checkbox.stories.tsx
+++ b/docs/src/components/checkbox.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/react";
 import { useRef, useState } from "react";
-import { Button, Checkbox } from "@moai/core";
+import { Button, Checkbox } from "../../../core/src";
 import { Book, someBooks } from "../utils/example";
 import { Utils } from "../utils/utils";
 

--- a/docs/src/components/date-input.stories.tsx
+++ b/docs/src/components/date-input.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/react/types-6-0";
 import { useState } from "react";
-import { DateInput } from "@moai/core";
+import { DateInput } from "../../../core/src";
 import { Utils } from "../utils/utils";
 
 const meta: Meta = {

--- a/docs/src/components/dialog.stories.tsx
+++ b/docs/src/components/dialog.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta } from "@storybook/react";
 import { useState } from "react";
-import { Button, Dialog, DivGrow, Paragraph } from "@moai/core";
-import { GalleryDialog } from "@moai/gallery";
+import { Button, Dialog, DivGrow, Paragraph } from "../../../core/src";
+import { GalleryDialog } from "../../../gallery/src";
 import { Utils } from "../utils/utils";
 
 const meta: Meta = {

--- a/docs/src/components/empty.stories.tsx.bk
+++ b/docs/src/components/empty.stories.tsx.bk
@@ -1,5 +1,5 @@
 import { Meta } from "@storybook/react";
-import { Button, Dialog, EmptyState } from "@moai/core";
+import { Button, Dialog, EmptyState } from "../../../core/src";
 
 
 export default {

--- a/docs/src/components/icon.stories.tsx
+++ b/docs/src/components/icon.stories.tsx
@@ -1,8 +1,8 @@
 import { Meta } from "@storybook/react";
 import { SVGAttributes } from "react";
 import { FaHome } from "react-icons/fa";
-import { Icon, text } from "@moai/core";
-import { GalleryIcon } from "@moai/gallery";
+import { Icon, text } from "../../../core/src";
+import { GalleryIcon } from "../../../gallery/src";
 import { Utils } from "../utils/utils";
 
 const meta: Meta = {

--- a/docs/src/components/input.stories.tsx
+++ b/docs/src/components/input.stories.tsx
@@ -2,9 +2,9 @@ import { Meta } from "@storybook/react";
 import * as Fm from "formik";
 import { useState } from "react";
 import { HiPhone } from "react-icons/hi";
-import { Button, Dialog, DivPx, Input } from "@moai/core";
-import { GalleryInput1 } from "@moai/gallery";
-import { GalleryInput2 } from "@moai/gallery";
+import { Button, Dialog, DivPx, Input } from "../../../core/src";
+import { GalleryInput1 } from "../../../gallery/src";
+import { GalleryInput2 } from "../../../gallery/src";
 import { Utils } from "../utils/utils";
 
 const meta: Meta = {

--- a/docs/src/components/pagination.stories.tsx
+++ b/docs/src/components/pagination.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/react";
 import { useCallback, useState } from "react";
-import { Pagination } from "@moai/core";
+import { Pagination } from "../../../core/src";
 import { Utils } from "../utils/utils";
 
 const meta: Meta = {

--- a/docs/src/components/pane.stories.tsx
+++ b/docs/src/components/pane.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta } from "@storybook/react";
-import { Pane } from "@moai/core";
+import { Pane } from "../../../core/src";
 import { Utils } from "../utils/utils";
 
 const meta: Meta = {

--- a/docs/src/components/popover.stories.tsx
+++ b/docs/src/components/popover.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta } from "@storybook/react";
-import { Button, Popover, PopoverPlacement } from "@moai/core";
+import { Button, Popover, PopoverPlacement } from "../../../core/src";
 import { PLACEMENTS } from "../utils/placement";
 import { Utils } from "../utils/utils";
 

--- a/docs/src/components/progress-circle.stories.tsx
+++ b/docs/src/components/progress-circle.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/react";
-import { ProgressCircle, ProgressCircleProps } from "@moai/core";
-import { GalleryProgress } from "@moai/gallery";
+import { ProgressCircle, ProgressCircleProps } from "../../../core/src";
+import { GalleryProgress } from "../../../gallery/src";
 import { Utils } from "../utils/utils";
 
 const meta: Meta = {

--- a/docs/src/components/radio-group-fake.tsx
+++ b/docs/src/components/radio-group-fake.tsx
@@ -1,4 +1,4 @@
-import { RadioOption } from "@moai/core";
+import { RadioOption } from "../../../core/src";
 
 /**
  * This is not a part of the source code. It exists only for Storybook's

--- a/docs/src/components/radio-group.stories.tsx
+++ b/docs/src/components/radio-group.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/react";
 import { useState } from "react";
-import { RadioGroup, RadioOption } from "@moai/core";
+import { RadioGroup, RadioOption } from "../../../core/src";
 import { Book, someBooks } from "../utils/example";
 import { Utils } from "../utils/utils";
 import { RadioOptionComponent } from "./radio-group-fake";

--- a/docs/src/components/radio.stories.tsx
+++ b/docs/src/components/radio.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/react";
 import { useState } from "react";
-import { Radio } from "@moai/core";
+import { Radio } from "../../../core/src";
 import { Book, someBooks } from "../utils/example";
 import { Utils } from "../utils/utils";
 

--- a/docs/src/components/select-fake.tsx
+++ b/docs/src/components/select-fake.tsx
@@ -1,4 +1,4 @@
-import { SelectOption } from "@moai/core";
+import { SelectOption } from "../../../core/src";
 
 /**
  * This is not a part of the source code. It exists only for Storybook's

--- a/docs/src/components/select.stories.tsx
+++ b/docs/src/components/select.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta } from "@storybook/react";
 import { useState } from "react";
-import { Select } from "@moai/core";
-import { GallerySelect } from "@moai/gallery";
+import { Select } from "../../../core/src";
+import { GallerySelect } from "../../../gallery/src";
 import { Utils } from "../utils/utils";
 import { SelectOptionComponent } from "./select-fake";
 

--- a/docs/src/components/step.stories.tsx
+++ b/docs/src/components/step.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta } from "@storybook/react";
-import { Steps } from "@moai/core";
+import { Steps } from "../../../core/src";
 
 export default {
 	title: "Draft/Steps",

--- a/docs/src/components/switcher-fake.tsx
+++ b/docs/src/components/switcher-fake.tsx
@@ -1,4 +1,4 @@
-import { SwitcherOption } from "@moai/core";
+import { SwitcherOption } from "../../../core/src";
 
 /**
  * This is not a part of the source code. It exists only for Storybook's

--- a/docs/src/components/switcher.stories.tsx
+++ b/docs/src/components/switcher.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta } from "@storybook/react/types-6-0";
 import { useState } from "react";
 import { FaAlignCenter, FaAlignLeft, FaAlignRight } from "react-icons/fa";
-import { Switcher, SwitcherOption } from "@moai/core";
+import { Switcher, SwitcherOption } from "../../../core/src";
 import { SwitcherOptionComponent } from "./switcher-fake";
 import { Utils } from "../utils/utils";
 

--- a/docs/src/components/tab-fake.tsx
+++ b/docs/src/components/tab-fake.tsx
@@ -1,4 +1,4 @@
-import { Tab } from "@moai/core";
+import { Tab } from "../../../core/src";
 
 /**
  * This is not a part of the source code. It exists only for Storybook's

--- a/docs/src/components/tab.stories.tsx
+++ b/docs/src/components/tab.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta } from "@storybook/react";
 import { useState } from "react";
-import { Button, DivPx, Switcher, Tab, Tabs } from "@moai/core";
-import { GalleryTab1, GalleryTab2 } from "@moai/gallery";
+import { Button, DivPx, Switcher, Tab, Tabs } from "../../../core/src";
+import { GalleryTab1, GalleryTab2 } from "../../../gallery/src";
 import { Utils } from "../utils/utils";
 import { TabComponent } from "./tab-fake";
 

--- a/docs/src/components/table-fake.tsx
+++ b/docs/src/components/table-fake.tsx
@@ -1,5 +1,5 @@
-import { TableColumn } from "@moai/core";
-import { TableExpandableProps } from "@moai/core";
+import { TableColumn } from "../../../core/src";
+import { TableExpandableProps } from "../../../core/src";
 
 /**
  * This is not a part of the source code. It exists only for Storybook's

--- a/docs/src/components/table.stories.tsx
+++ b/docs/src/components/table.stories.tsx
@@ -1,8 +1,8 @@
 import { Meta } from "@storybook/react";
 import { useState } from "react";
-import { Pane, Table, TableColumn } from "@moai/core";
-import { Robot, ROBOTS } from "@moai/gallery";
-import { GalleryTable } from "@moai/gallery";
+import { Pane, Table, TableColumn } from "../../../core/src";
+import { Robot, ROBOTS } from "../../../gallery/src";
+import { GalleryTable } from "../../../gallery/src";
 import { Book, someBooks } from "../utils/example";
 import { Utils } from "../utils/utils";
 import { TableColumnComponent, TableExpandableComponent } from "./table-fake";

--- a/docs/src/components/tag.stories.tsx
+++ b/docs/src/components/tag.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta } from "@storybook/react";
-import { Tag } from "@moai/core";
+import { Tag } from "../../../core/src";
 import { Utils } from "../utils/utils";
-import { GalleryTag } from "@moai/gallery";
+import { GalleryTag } from "../../../gallery/src";
 
 const meta: Meta = {
 	title: "Components/Tag",

--- a/docs/src/components/text-area.stories.tsx
+++ b/docs/src/components/text-area.stories.tsx
@@ -1,4 +1,4 @@
-import { TextArea } from "@moai/core";
+import { TextArea } from "../../../core/src";
 import { Utils } from "../utils/utils";
 
 export default {

--- a/docs/src/components/time-input.stories.tsx
+++ b/docs/src/components/time-input.stories.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { TimeInput } from "@moai/core";
+import { TimeInput } from "../../../core/src";
 import { Utils } from "../utils/utils";
 
 const meta = {

--- a/docs/src/components/toast-fake.tsx
+++ b/docs/src/components/toast-fake.tsx
@@ -1,4 +1,4 @@
-import { ToastType } from "@moai/core";
+import { ToastType } from "../../../core/src";
 
 interface Props {
 	/**

--- a/docs/src/components/toast.stories.tsx
+++ b/docs/src/components/toast.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta } from "@storybook/react";
 import { useState } from "react";
-import { Button, toast, ToastPane } from "@moai/core";
-import { GalleryToast } from "@moai/gallery";
+import { Button, toast, ToastPane } from "../../../core/src";
+import { GalleryToast } from "../../../gallery/src";
 import { Utils } from "../utils/utils";
 import { ToastFunction } from "./toast-fake";
 

--- a/docs/src/components/tooltip.stories.tsx
+++ b/docs/src/components/tooltip.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta } from "@storybook/react";
-import { Tooltip, TooltipProps } from "@moai/core";
+import { Tooltip, TooltipProps } from "../../../core/src";
 import { PLACEMENTS } from "../utils/placement";
 import { Utils } from "../utils/utils";
 

--- a/docs/src/guides/gallery.stories.mdx
+++ b/docs/src/guides/gallery.stories.mdx
@@ -1,5 +1,5 @@
 import { Meta } from "@storybook/addon-docs";
-import { Gallery } from "@moai/gallery";
+import { Gallery } from "../../../gallery/src";
 
 <Meta title="Intro/Gallery" />
 

--- a/docs/src/guides/proper-start.stories.mdx
+++ b/docs/src/guides/proper-start.stories.mdx
@@ -112,7 +112,7 @@ After the setup, just import the components from the package to use. All
 components are exported at the top level:
 
 ```tsx
-import { Button } from "@moai/core";
+import { Button } from "../../../core/src";
 
 export const Foo = (): JSX.Element => <Button>Hello</Button>;
 ```

--- a/docs/src/guides/quick-start.stories.mdx
+++ b/docs/src/guides/quick-start.stories.mdx
@@ -26,7 +26,7 @@ Finally, add either `light` or `dark` class to your `html` tag:
 And you can use Moai's components:
 
 ```tsx
-import { Button } from "@moai/core";
+import { Button } from "../../../core/src";
 
 export const Foo = (): JSX.Element => <Button>Hello</Button>;
 ```

--- a/docs/src/patterns/form.stories.tsx
+++ b/docs/src/patterns/form.stories.tsx
@@ -2,7 +2,7 @@ import { Meta } from "@storybook/react/types-6-0";
 import { ErrorMessage, Field, Form, Formik, FormikErrors } from "formik";
 import { CSSProperties, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
-import { Button, FormError, Input, TextArea } from "@moai/core";
+import { Button, FormError, Input, TextArea } from "../../../core/src";
 import { Utils } from "../utils/utils";
 
 const meta: Meta = {
@@ -58,7 +58,7 @@ const postToServer = async (values: FormValues): Promise<void> => {
 export const Primary = (): JSX.Element => <div>Skipped</div>;
 
 export const FormikExample = (): JSX.Element => {
-	/* import { Input, Button, FormError } from "@moai/core" */
+	/* import { Input, Button, FormError } from "../../../core/src" */
 
 	const title = (
 		<div>
@@ -113,7 +113,7 @@ Formik's [Field][1] component:
 
 ~~~tsx
 import { Field } from "formik";
-import { Input } from "@moai/core";
+import { Input } from "../../../core/src";
 
 <label htmlFor="email">Email</label>
 <Field id="email" type="email" name="email" as={Input} />
@@ -124,7 +124,7 @@ To show errors, pass FormError to the "component" prop of Formik's
 
 ~~~tsx
 import { ErrorMessage } from "formik";
-import { FormError } from "@moai/core";
+import { FormError } from "../../../core/src";
 
 <ErrorMessage name="email" component={FormError} />
 ~~~
@@ -136,7 +136,7 @@ Full example:
 });
 
 export const ReactHookForm = (): JSX.Element => {
-	/* import { Input, Button, FormError } from "@moai/core" */
+	/* import { Input, Button, FormError } from "../../../core/src" */
 
 	const { control, formState, handleSubmit } = useForm<FormValues>();
 	const { errors } = formState;
@@ -198,7 +198,7 @@ To use Moai's input components with React Hook Form, [render][2] them in the
 
 ~~~tsx
 import { Controller } from "react-hook-form";
-import { Input } from "@moai/core";
+import { Input } from "../../../core/src";
 
 <label htmlFor="email">Email</label>
 <Controller
@@ -218,7 +218,7 @@ To show errors, pass RHF's [error messages][3] as children of Moai's FormError
 component:
 
 ~~~tsx
-import { FormError } from "@moai/core";
+import { FormError } from "../../../core/src";
 
 <FormError children={errors.email?.message} />
 ~~~

--- a/docs/src/patterns/icon.stories.tsx
+++ b/docs/src/patterns/icon.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta } from "@storybook/react/types-6-0";
 import { SVGAttributes } from "react";
 import { RiSearchLine } from "react-icons/ri";
-import { Button } from "@moai/core";
+import { Button } from "../../../core/src";
 import { Utils } from "../utils/utils";
 
 const meta: Meta = {

--- a/docs/src/utils/page/component.tsx
+++ b/docs/src/utils/page/component.tsx
@@ -8,7 +8,7 @@ import {
 } from "@storybook/addon-docs";
 import { Meta } from "@storybook/react";
 import React from "react";
-import { background } from "@moai/core";
+import { background } from "../../../../core/src";
 import s from "./component.module.css";
 
 interface Props {

--- a/docs/src/utils/placement.ts
+++ b/docs/src/utils/placement.ts
@@ -1,4 +1,4 @@
-import { PopoverPlacement } from "@moai/core";
+import { PopoverPlacement } from "../../../core/src";
 
 export const PLACEMENTS: PopoverPlacement[] = [
 	"top",


### PR DESCRIPTION
TSDoc (like component and prop descriptions) are missing after #252, because react-docgen cannot grab them if the source and the type are in different files (which is the case where we use the distribution build)

This temporarily reverse that changes, so "docs" now import "core"'s source directly, so react-docgen can generate types for us.

Moving forward we should figure out a way to use the distribution build..